### PR TITLE
Add cwd option to add_process

### DIFF
--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -40,6 +40,7 @@ def _execute_process(
     completion_callback: typing.Optional[CompletionCallback] = None,
     completion_trigger: typing.Optional[multiprocessing.synchronize.Event] = None,
     environment: typing.Optional[typing.Dict[str, str]] = None,
+    cwd: typing.Optional[pathlib.Path] = None,
 ) -> tuple[subprocess.Popen, typing.Optional[threading.Thread]]:
     thread_out = None
 
@@ -51,6 +52,7 @@ def _execute_process(
                 stderr=err,
                 universal_newlines=True,
                 env=environment,
+                cwd=cwd,
             )
 
     if completion_callback or completion_trigger:
@@ -138,6 +140,7 @@ class Executor:
         script: typing.Optional[pathlib.Path] = None,
         input_file: typing.Optional[pathlib.Path] = None,
         env: typing.Optional[typing.Dict[str, str]] = None,
+        cwd: typing.Optional[pathlib.Path] = None,
         completion_callback: typing.Optional[CompletionCallback] = None,
         completion_trigger: typing.Optional[multiprocessing.synchronize.Event] = None,
         **kwargs,
@@ -186,6 +189,8 @@ class Executor:
             you should provide it as such and perform the upload manually, by default None
         env : typing.Dict[str, str], optional
             environment variables for process
+        cwd: typing.Optional[pathlib.Path], optional
+            working directory to execute the process within
         completion_callback : typing.Callable | None, optional
             callback to run when process terminates
         completion_trigger : multiprocessing.Event | None, optional
@@ -252,6 +257,7 @@ class Executor:
                 completion_callback,
                 completion_trigger,
                 env,
+                cwd,
             )
         )
 

--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -208,10 +208,20 @@ class Executor:
             )
 
         if script:
-            self._runner.save_file(file_path=script, category="code")
+            if cwd:
+                self._runner.save_file(
+                    file_path=os.path.join(cwd, script), category="code"
+                )
+            else:
+                self._runner.save_file(file_path=script, category="code")
 
         if input_file:
-            self._runner.save_file(file_path=input_file, category="input")
+            if cwd:
+                self._runner.save_file(
+                    file_path=os.path.join(cwd, input_file), category="input"
+                )
+            else:
+                self._runner.save_file(file_path=input_file, category="input")
 
         command: typing.List[str] = []
 

--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -208,20 +208,10 @@ class Executor:
             )
 
         if script:
-            if cwd:
-                self._runner.save_file(
-                    file_path=os.path.join(cwd, script), category="code"
-                )
-            else:
-                self._runner.save_file(file_path=script, category="code")
+            self._runner.save_file(file_path=script, category="code")
 
         if input_file:
-            if cwd:
-                self._runner.save_file(
-                    file_path=os.path.join(cwd, input_file), category="input"
-                )
-            else:
-                self._runner.save_file(file_path=input_file, category="input")
+            self._runner.save_file(file_path=input_file, category="input")
 
         command: typing.List[str] = []
 

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -660,6 +660,7 @@ class Run:
         ] = None,
         completion_trigger: typing.Optional[multiprocessing.synchronize.Event] = None,
         env: typing.Optional[typing.Dict[str, str]] = None,
+        cwd: typing.Optional[pathlib.Path] = None,
         **cmd_kwargs,
     ) -> None:
         """Add a process to be executed to the executor.
@@ -715,6 +716,8 @@ class Run:
             this trigger event is set when the processes completes
         env : typing.Dict[str, str], optional
             environment variables for process
+        cwd: typing.Optional[pathlib.Path], optional
+            working directory to execute the process within
         **kwargs : Any, ..., optional
             all other keyword arguments are interpreted as options to the command
         """
@@ -773,6 +776,7 @@ class Run:
             completion_callback=completion_callback,  # type: ignore
             completion_trigger=completion_trigger,
             env=env,
+            cwd=cwd,
             **cmd_kwargs,
         )
 

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -653,8 +653,8 @@ class Run:
         identifier: str,
         *cmd_args,
         executable: typing.Optional[typing.Union[str, pathlib.Path]] = None,
-        script: typing.Optional[pydantic.FilePath] = None,
-        input_file: typing.Optional[pydantic.FilePath] = None,
+        script: typing.Optional[typing.Union[str, pathlib.Path]] = None,
+        input_file: typing.Optional[typing.Union[str, pathlib.Path]] = None,
         completion_callback: typing.Optional[
             typing.Callable[[int, str, str], None]
         ] = None,

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -653,8 +653,8 @@ class Run:
         identifier: str,
         *cmd_args,
         executable: typing.Optional[typing.Union[str, pathlib.Path]] = None,
-        script: typing.Optional[typing.Union[str, pathlib.Path]] = None,
-        input_file: typing.Optional[typing.Union[str, pathlib.Path]] = None,
+        script: typing.Optional[pydantic.FilePath] = None,
+        input_file: typing.Optional[pydantic.FilePath] = None,
         completion_callback: typing.Optional[
             typing.Callable[[int, str, str], None]
         ] = None,
@@ -704,10 +704,10 @@ class Run:
             positional argument, by default None
         *positional_arguments : Any, ..., optional
             all other positional arguments are taken to be part of the command to execute
-        script : str | None, optional
+        script : pydantic.FilePath | None, optional
             the script to run, note this only work if the script is not an option, if this is the case
             you should provide it as such and perform the upload manually, by default None
-        input_file : str | None, optional
+        input_file : pydantic.FilePath | None, optional
             the input file to run, note this only work if the input file is not an option, if this is the case
             you should provide it as such and perform the upload manually, by default None
         completion_callback : typing.Callable | None, optional
@@ -717,7 +717,8 @@ class Run:
         env : typing.Dict[str, str], optional
             environment variables for process
         cwd: typing.Optional[pathlib.Path], optional
-            working directory to execute the process within
+            working directory to execute the process within. Note that executable, input and script file paths should
+            be absolute or relative to the directory where this method is called, not relative to the new working directory.
         **kwargs : Any, ..., optional
             all other keyword arguments are interpreted as options to the command
         """

--- a/tests/functional/test_run_process_cwd.py
+++ b/tests/functional/test_run_process_cwd.py
@@ -1,0 +1,53 @@
+import unittest
+import uuid
+import tempfile
+import simvue
+from simvue import Run
+import os
+import filecmp
+
+class TestRunProcess(unittest.TestCase):
+    def test_processes_cwd(self):
+        """Check that cwd argument works correctly in add_process.
+
+        Create a temporary directory, and a python file inside that directory. Check that if only the file name
+        is passed to add_process as the script, and the directory is specified as the cwd argument, that the process
+        runs correctly and the script is uploaded as expected.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with tempfile.NamedTemporaryFile(dir=temp_dir, suffix=".py") as temp_file:
+                with open(temp_file.name, "w") as out_f:
+                    out_f.writelines([
+                        "import time\n",
+                        "time.sleep(10)\n"
+                    ])
+                    file_name = os.path.basename(temp_file.name)
+                    
+                with Run() as run:
+                    run.init(
+                        name='test-%s' % str(uuid.uuid4()),
+                        folder='/test-%s' % str(uuid.uuid4())
+                    )
+                    run_id = run._id
+                    run.add_process(
+                        identifier="sleep_10_process",
+                        executable="python",
+                        script=file_name,
+                        cwd=temp_dir
+                    )
+
+                client = simvue.Client()
+
+                # Check that run existed for more than 10s, meaning the process ran correctly
+                data = client.get_run(run_id)
+                runtime = data['runtime']
+                runtime_seconds = float(runtime.split(":")[-1])
+                self.assertGreater(runtime_seconds, 10.0)
+
+                # Check that the script was uploaded to the run correctly
+                os.makedirs(os.path.join(temp_dir, "downloaded"))
+                client.get_artifact_as_file(run_id, file_name, path=os.path.join(temp_dir, "downloaded"))
+                assert filecmp.cmp(os.path.join(temp_dir, "downloaded", file_name), temp_file.name)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
For the FDS connector to be able to support executing a simulation in a different working directory to the place where the connector is called, need to be able to specify a working directory for the process to use (since FDS always puts results into the working directory). Added this as an option to the `add_process` method, which then just passes the `cwd` parameter through to the subprocess.

This now assumes that the path to the `script` or `input_file` are relative to the `cwd` parameter, so have updated the file upload in `add_process` to join together these paths before trying to find the file if `cwd` is specified. Also had to loosen the typing for `script` and `input_file` to accept a string or Path, since the path provided for either of these may not exist if `cwd` is specified.

Added a test which checks this functionality