### PR TITLE
Retrieve full list of alerts when run not specified

### DIFF
--- a/tests/functional/test_get_alerts.py
+++ b/tests/functional/test_get_alerts.py
@@ -19,7 +19,7 @@ class TestGetAlerts(unittest.TestCase):
         folder = '/test-%s' % str(uuid.uuid4())
         name = common.RUNNAME3
         run.init(name, folder=folder)
-        run.add_alert(
+        run.create_alert(
             name='value_below_1',
             source='metrics',
             frequency=1,
@@ -28,7 +28,7 @@ class TestGetAlerts(unittest.TestCase):
             metric='test_metric',
             window=2
         )
-        run.add_alert(
+        run.create_alert(
             name='value_above_1',
             source='metrics',
             frequency=1,

--- a/tests/refactor/test_client.py
+++ b/tests/refactor/test_client.py
@@ -17,11 +17,18 @@ def test_get_events(create_test_run: tuple[sv_run.Run, dict]) -> None:
 
 @pytest.mark.dependency
 @pytest.mark.client
-def test_get_alerts(create_test_run: tuple[sv_run.Run, dict]) -> None:
+@pytest.mark.parametrize(
+    "from_run", (True, False)
+)
+def test_get_alerts(create_test_run: tuple[sv_run.Run, dict], from_run: bool) -> None:
     client = svc.Client()
-    assert (
-        len(client.get_alerts(create_test_run[1]["run_id"], critical_only=False)) == 5
-    )
+
+    if from_run:
+        assert (
+            len(client.get_alerts(create_test_run[1]["run_id"], critical_only=False)) == 5
+        )
+    else:
+        client.get_alerts(names_only=True)
 
 
 @pytest.mark.dependency

--- a/tests/refactor/test_client.py
+++ b/tests/refactor/test_client.py
@@ -28,7 +28,7 @@ def test_get_alerts(create_test_run: tuple[sv_run.Run, dict], from_run: bool) ->
             len(client.get_alerts(create_test_run[1]["run_id"], critical_only=False)) == 5
         )
     else:
-        client.get_alerts(names_only=True)
+        assert client.get_alerts(names_only=True)
 
 
 @pytest.mark.dependency


### PR DESCRIPTION
Adds the option to not specify a run when using `Client.get_alerts` to instead retrieve all alerts.