### PR TITLE
Environment variables within poetry environment CI

### DIFF
--- a/.github/workflows/test_client_macos.yml
+++ b/.github/workflows/test_client_macos.yml
@@ -22,8 +22,9 @@ jobs:
         python -m pip install poetry
     - name: Test with pytest
       run: |
-        export SIMVUE_URL=${{ secrets.SIMVUE_URL }}
-        export SIMVUE_TOKEN=${{ secrets.SIMVUE_TOKEN }}
         poetry install --all-extras
         poetry run python -m pip install torch
-        poetry run pytest tests/unit/ tests/refactor/ -m 'not scenario'
+        poetry run \
+        SIMVUE_URL=${{ secrets.SIMVUE_URL }} \
+        SIMVUE_TOKEN=${{ secrets.SIMVUE_TOKEN }} \
+        pytest tests/unit/ tests/refactor/ -m 'not scenario'

--- a/.github/workflows/test_client_ubuntu.yml
+++ b/.github/workflows/test_client_ubuntu.yml
@@ -28,11 +28,12 @@ jobs:
       run: python -m pip install poetry
     - name: Test with pytest
       run: |
-        export SIMVUE_URL=${{ secrets.SIMVUE_URL }}
-        export SIMVUE_TOKEN=${{ secrets.SIMVUE_TOKEN }}
         poetry install --all-extras
         poetry run python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
-        poetry run pytest -x --cov --cov-report=xml tests/unit/ tests/refactor/ -m 'not scenario'
+        poetry run \
+          SIMVUE_URL=${{ secrets.SIMVUE_URL }} \
+          SIMVUE_TOKEN=${{ secrets.SIMVUE_TOKEN }} \
+          pytest -x --cov --cov-report=xml tests/unit/ tests/refactor/ -m 'not scenario'
     - name: Upload coverage reports to Codecov
       run: |
         curl -Os https://uploader.codecov.io/latest/linux/codecov

--- a/.github/workflows/test_client_windows.yml
+++ b/.github/workflows/test_client_windows.yml
@@ -23,8 +23,9 @@ jobs:
     - name: Test with pytest
       shell: bash
       run: |
-        export SIMVUE_URL=${{ secrets.SIMVUE_URL }}
-        export SIMVUE_TOKEN=${{ secrets.SIMVUE_TOKEN }}
         poetry install --all-extras
         poetry run python -m pip install torch
-        poetry run pytest tests/unit/ tests/refactor/ -m 'not scenario' -m 'not unix'
+        poetry run \
+        SIMVUE_URL=${{ secrets.SIMVUE_URL }} \
+        SIMVUE_TOKEN=${{ secrets.SIMVUE_TOKEN }} \
+        pytest tests/unit/ tests/refactor/ -m 'not scenario' -m 'not unix'


### PR DESCRIPTION
As `export` us ignored within a poetry environment, this applies the environment variables to the pytest command call in the CI