### PR TITLE
Enable resource metrics by default

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -122,7 +122,7 @@ class Run:
         self._active: bool = False
         self._aborted: bool = False
         self._url, self._token = get_auth()
-        self._resources_metrics_interval: typing.Optional[int] = None
+        self._resources_metrics_interval: typing.Optional[int] = HEARTBEAT_INTERVAL
         self._headers: dict[str, str] = {"Authorization": f"Bearer {self._token}"}
         self._simvue: typing.Optional[SimvueBaseClass] = None
         self._pid: typing.Optional[int] = 0


### PR DESCRIPTION
Enables resource metrics recording by default, for some reason this had been set to `None` meaning resource metrics were not recorded.