### PR TITLE
Only set status to 'terminated' if the run is active

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -163,10 +163,10 @@ class Run:
         if not _is_running:
             return
 
-        self.set_status("terminated" if _is_terminated else "failed")
-
         if not self._active:
             return
+
+        self.set_status("terminated" if _is_terminated else "failed")
 
         # If the dispatcher has already been aborted then this will
         # fail so just continue without the event


### PR DESCRIPTION
Checks if the run is active before setting status, this is relevant if the user uses Ctrl-C before the `Run` has been initialised.