### PR TITLE
Fix incorrect function call in sender for configuration

### DIFF
--- a/simvue/sender.py
+++ b/simvue/sender.py
@@ -172,7 +172,7 @@ def process(run):
     # Create run if it hasn't previously been created
     created_file = f"{current}/init"
     name = None
-    config = SimvueConfiguration()
+    config = SimvueConfiguration.fetch()
     if not os.path.isfile(created_file):
         remote = Remote(
             name=run_init["name"], uniq_id=id, config=config, suppress_errors=False


### PR DESCRIPTION
Fixes incorrect use of `SimvueConfiguration` in `sender.py:sender`.

Closes #550 