### PR TITLE
Allow non-authentication configurations to be read as key `tool.simvue` from `pyproject.toml`

### DIFF
--- a/tests/refactor/test_config.py
+++ b/tests/refactor/test_config.py
@@ -14,8 +14,8 @@ from simvue.config.user import SimvueConfiguration
     ids=("use_env", "no_env")
 )
 @pytest.mark.parametrize(
-    "use_file", (None, "basic", "extended"),
-    ids=("no_file", "basic_file", "extended_file")
+    "use_file", (None, "basic", "extended", "pyproject.toml"),
+    ids=("no_file", "basic_file", "extended_file", "pyproject_toml")
 )
 @pytest.mark.parametrize(
     "use_args", (True, False),
@@ -35,8 +35,11 @@ def test_config_setup(
     _other_url: str = "http://simvue.example.com/"
     _arg_url: str = "http://simvue.example.io/"
     _description: str = "test case for runs"
+    _description_ppt: str = "test case for runs using pyproject.toml"
     _folder: str = "/test-case"
+    _folder_ppt: str = "/test-case-ppt"
     _tags: list[str] = ["tag-test", "other-tag"]
+    _tags_ppt: list[str] = ["tag-test-ppt", "other-tag-ppt"]
 
     # Deactivate the server checks for this test
     monkeypatch.setenv("SIMVUE_NO_SERVER_CHECK", "True")
@@ -49,10 +52,24 @@ def test_config_setup(
 
     with tempfile.TemporaryDirectory() as temp_d:
         _config_file = None
+        _ppt_file = None
         if use_file:
+            if use_file == "pyproject.toml":
+                _lines_ppt: str = f"""
+[tool.poetry]
+name = "simvue_testing"
+version = "0.1.0"
+description = "A dummy test project"
+
+[tool.simvue.run]
+description = "{_description_ppt}"
+folder = "{_folder_ppt}"
+tags = {_tags_ppt}
+"""
+                with open((_ppt_file := pathlib.Path(temp_d).joinpath("pyproject.toml")), "w") as out_f:
+                    out_f.write(_lines_ppt)
             with open(_config_file := pathlib.Path(temp_d).joinpath("simvue.toml"), "w") as out_f:
-                if use_file:
-                    _lines: str = f"""
+                _lines: str = f"""
 [server]
 url = "{_url}"
 token = "{_token}"
@@ -72,7 +89,15 @@ tags = {_tags}
             SimvueConfiguration.config_file.cache_clear()
 
         mocker.patch("simvue.config.parameters.get_expiry", lambda *_, **__: 1e10)
-        mocker.patch("simvue.config.user.sv_util.find_first_instance_of_file", lambda *_, **__: _config_file)
+
+
+        def _mocked_find(file_names: list[str], *_, ppt_file=_ppt_file, conf_file=_config_file, **__) -> str:
+            if "pyproject.toml" in file_names:
+                return ppt_file
+            else:
+                return conf_file
+
+        mocker.patch("simvue.config.user.sv_util.find_first_instance_of_file", _mocked_find)
 
         import simvue.config.user
 
@@ -88,7 +113,7 @@ tags = {_tags}
         else:
             _config = simvue.config.user.SimvueConfiguration.fetch()
 
-        if use_file:
+        if use_file and use_file != "pyproject.toml":
             assert _config.config_file() == _config_file
 
         if use_env:
@@ -97,7 +122,7 @@ tags = {_tags}
         elif use_args:
             assert _config.server.url == _arg_url
             assert _config.server.token == _arg_token
-        elif use_file:
+        elif use_file and use_file != "pyproject.toml":
             assert _config.server.url == _url
             assert _config.server.token == _token
             assert _config.offline.cache == temp_d
@@ -106,6 +131,10 @@ tags = {_tags}
             assert _config.run.description == _description
             assert _config.run.folder == _folder
             assert _config.run.tags == _tags
+        elif use_file == "pyproject.toml":
+            assert _config.run.description == _description_ppt
+            assert _config.run.folder == _folder_ppt
+            assert _config.run.tags == _tags_ppt
         elif use_file:
             assert _config.run.folder == "/"
             assert not _config.run.description


### PR DESCRIPTION
Adds ability to include key `tool.simvue` within a project `pyproject.toml` for setting configurations.
**NOTE**: This does not support `server.token`, `server.url` or `offline.cache` as these are authentication configurations, or hard coded paths which should not be added to any project repository.

closes #569 