### PR TITLE
Use `None` to retrieve all metric values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Drop support for INI based configuration files.
+* Retrieve all metric values if `max_points` is unspecified or set to `None`.
 
 ## [v1.1.1](https://github.com/simvue-io/client/releases/tag/v1.1.1) - 2024-10-22
 

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -1038,9 +1038,9 @@ class Client:
         run_ids: list[str],
         xaxis: str,
         aggregate: bool,
-        max_points: int = -1,
+        max_points: typing.Optional[int] = None,
     ) -> dict[str, typing.Any]:
-        params: dict[str, typing.Union[str, int]] = {
+        params: dict[str, typing.Union[str, int, None]] = {
             "runs": json.dumps(run_ids),
             "aggregate": aggregate,
             "metrics": json.dumps(metric_names),
@@ -1162,7 +1162,7 @@ class Client:
             run_ids=run_ids,
             xaxis=xaxis,
             aggregate=aggregate,
-            max_points=max_points or -1,
+            max_points=max_points,
         )
 
         if not run_metrics:


### PR DESCRIPTION
# Retrieve all metric values by default

**Issue:** Closes #548 

**Python Version(s) Tested:** 3.13.0

**Operating System(s):** Ubuntu 24.10

## 📝 Summary

`Client.get_metric_values(...)` will now return all points if `max_points = None` or is unspecified.

## 🔄 Changes

Updated default to be `None` and not `-1`

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [ ] Pre-commit hooks passing.
- [ ] Quality checks passing.
