### PR TITLE
Propogate URL and Token into fetch

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -159,7 +159,7 @@ class Run:
         self._data: dict[str, typing.Any] = {}
         self._step: int = 0
         self._active: bool = False
-        self._config = SimvueConfiguration.fetch()
+        self._config = SimvueConfiguration.fetch(server_url, server_token)
 
         logging.getLogger(self.__class__.__module__).setLevel(
             logging.DEBUG


### PR DESCRIPTION
# Propogate Server URL and Token from `__init__` into `fetch()`

**Issue:** https://github.com/simvue-io/python-api/issues/583

**Python Version(s) Tested:** 3.10

**Operating System(s):** Ubuntu 22.04

## 📝 Summary
v1.1 added option to specify server URL and Token in `__init__` of Run class, but these were not being passed into `SimvueConfiguration.fetch()` and so would never be set.

## 🔍 Diagnosis
Identified when updating Integrations repo

## 🔄 Changes
Server URL and Token now passed correctly. 

## ✔️ Checklist
- [x] Unit and integration tests passing.
- [x] Pre-commit hooks passing.
- [x] Quality checks passing.
