### PR TITLE
Fix wrong attribute in offline directory retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## [v1.1.2](https://github.com/simvue-io/client/releases/tag/v1.1.2) - 2024-11-06
+
+* Fix bug in offline mode directory retrieval.
 ## [v1.1.1](https://github.com/simvue-io/client/releases/tag/v1.1.1) - 2024-10-22
 
 * Add missing `offline.cache` key to TOML config.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -42,6 +42,6 @@ keywords:
   - alerting
   - simulation
 license: Apache-2.0
-commit: a475a0e3f6e48257f8d2d04d0ddf1652e2d9e924
-version: 1.1.1
-date-released: '2024-10-22'
+commit: e220740c747a56de0915d583918e1999d253fdfc
+version: 1.1.2
+date-released: '2024-11-06'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "simvue"
-version = "1.1.1"
+version = "1.1.2"
 description = "Simulation tracking and monitoring"
 authors = ["Simvue Development Team <info@simvue.io>"]
 license = "Apache v2"

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -106,18 +106,19 @@ class Client:
         server_url : str, optional
             specify URL, if unset this is read from the config file
         """
-        self._config = SimvueConfiguration.fetch(
+        self._user_config = SimvueConfiguration.fetch(
             server_token=server_token, server_url=server_url
         )
 
         for label, value in zip(
-            ("URL", "API token"), (self._config.server.url, self._config.server.url)
+            ("URL", "API token"),
+            (self._user_config.server.url, self._user_config.server.url),
         ):
             if not value:
                 logger.warning(f"No {label} specified")
 
         self._headers: dict[str, str] = {
-            "Authorization": f"Bearer {self._config.server.token}"
+            "Authorization": f"Bearer {self._user_config.server.token}"
         }
 
     def _get_json_from_response(
@@ -182,7 +183,9 @@ class Client:
         params: dict[str, str] = {"filters": json.dumps([f"name == {name}"])}
 
         response: requests.Response = requests.get(
-            f"{self._config.server.url}/api/runs", headers=self._headers, params=params
+            f"{self._user_config.server.url}/api/runs",
+            headers=self._headers,
+            params=params,
         )
 
         json_response = self._get_json_from_response(
@@ -232,7 +235,7 @@ class Client:
         """
 
         response: requests.Response = requests.get(
-            f"{self._config.server.url}/api/runs/{run_id}", headers=self._headers
+            f"{self._user_config.server.url}/api/runs/{run_id}", headers=self._headers
         )
 
         json_response = self._get_json_from_response(
@@ -349,7 +352,9 @@ class Client:
         }
 
         response = requests.get(
-            f"{self._config.server.url}/api/runs", headers=self._headers, params=params
+            f"{self._user_config.server.url}/api/runs",
+            headers=self._headers,
+            params=params,
         )
 
         response.raise_for_status()
@@ -398,7 +403,7 @@ class Client:
         """
 
         response = requests.delete(
-            f"{self._config.server.url}/api/runs/{run_id}",
+            f"{self._user_config.server.url}/api/runs/{run_id}",
             headers=self._headers,
         )
 
@@ -434,7 +439,7 @@ class Client:
         params: dict[str, str] = {"filters": json.dumps([f"path == {path}"])}
 
         response: requests.Response = requests.get(
-            f"{self._config.server.url}/api/folders",
+            f"{self._user_config.server.url}/api/folders",
             headers=self._headers,
             params=params,
         )
@@ -479,7 +484,7 @@ class Client:
         params: dict[str, bool] = {"runs_only": True, "runs": True}
 
         response = requests.delete(
-            f"{self._config.server.url}/api/folders/{folder_id}",
+            f"{self._user_config.server.url}/api/folders/{folder_id}",
             headers=self._headers,
             params=params,
         )
@@ -545,7 +550,7 @@ class Client:
         params |= {"recursive": recursive}
 
         response = requests.delete(
-            f"{self._config.server.url}/api/folders/{folder_id}",
+            f"{self._user_config.server.url}/api/folders/{folder_id}",
             headers=self._headers,
             params=params,
         )
@@ -576,7 +581,8 @@ class Client:
             the unique identifier for the alert
         """
         response = requests.delete(
-            f"{self._config.server.url}/api/alerts/{alert_id}", headers=self._headers
+            f"{self._user_config.server.url}/api/alerts/{alert_id}",
+            headers=self._headers,
         )
 
         if response.status_code == http.HTTPStatus.OK:
@@ -611,7 +617,7 @@ class Client:
         params: dict[str, str] = {"runs": json.dumps([run_id])}
 
         response: requests.Response = requests.get(
-            f"{self._config.server.url}/api/artifacts",
+            f"{self._user_config.server.url}/api/artifacts",
             headers=self._headers,
             params=params,
         )
@@ -637,7 +643,7 @@ class Client:
         params: dict[str, str | None] = {"name": name}
 
         response = requests.get(
-            f"{self._config.server.url}/api/runs/{run_id}/artifacts",
+            f"{self._user_config.server.url}/api/runs/{run_id}/artifacts",
             headers=self._headers,
             params=params,
         )
@@ -679,7 +685,7 @@ class Client:
         body: dict[str, str | None] = {"id": run_id, "reason": reason}
 
         response = requests.put(
-            f"{self._config.server.url}/api/runs/abort",
+            f"{self._user_config.server.url}/api/runs/abort",
             headers=self._headers,
             json=body,
         )
@@ -873,7 +879,7 @@ class Client:
         params: dict[str, typing.Optional[str]] = {"category": category}
 
         response: requests.Response = requests.get(
-            f"{self._config.server.url}/api/runs/{run_id}/artifacts",
+            f"{self._user_config.server.url}/api/runs/{run_id}/artifacts",
             headers=self._headers,
             params=params,
         )
@@ -966,7 +972,7 @@ class Client:
         }
 
         response: requests.Response = requests.get(
-            f"{self._config.server.url}/api/folders",
+            f"{self._user_config.server.url}/api/folders",
             headers=self._headers,
             params=params,
         )
@@ -1013,7 +1019,7 @@ class Client:
         params = {"runs": json.dumps([run_id])}
 
         response: requests.Response = requests.get(
-            f"{self._config.server.url}/api/metrics/names",
+            f"{self._user_config.server.url}/api/metrics/names",
             headers=self._headers,
             params=params,
         )
@@ -1049,7 +1055,7 @@ class Client:
         }
 
         metrics_response: requests.Response = requests.get(
-            f"{self._config.server.url}/api/metrics",
+            f"{self._user_config.server.url}/api/metrics",
             headers=self._headers,
             params=params,
         )
@@ -1311,7 +1317,7 @@ class Client:
         }
 
         response = requests.get(
-            f"{self._config.server.url}/api/events",
+            f"{self._user_config.server.url}/api/events",
             headers=self._headers,
             params=params,
         )
@@ -1368,7 +1374,7 @@ class Client:
         params: dict[str, int] = {"count": count_limit or 0, "start": start_index or 0}
         if not run_id:
             response = requests.get(
-                f"{self._config.server.url}/api/alerts/",
+                f"{self._user_config.server.url}/api/alerts/",
                 headers=self._headers,
                 params=params,
             )
@@ -1380,7 +1386,7 @@ class Client:
             )
         else:
             response = requests.get(
-                f"{self._config.server.url}/api/runs/{run_id}",
+                f"{self._user_config.server.url}/api/runs/{run_id}",
                 headers=self._headers,
                 params=params,
             )
@@ -1457,7 +1463,9 @@ class Client:
         """
         params = {"count": count_limit or 0, "start": start_index or 0}
         response = requests.get(
-            f"{self._config.server.url}/api/tags", headers=self._headers, params=params
+            f"{self._user_config.server.url}/api/tags",
+            headers=self._headers,
+            params=params,
         )
 
         json_response = self._get_json_from_response(
@@ -1491,7 +1499,7 @@ class Client:
         """
 
         response = requests.delete(
-            f"{self._config.server.url}/api/tags/{tag_id}",
+            f"{self._user_config.server.url}/api/tags/{tag_id}",
             headers=self._headers,
         )
 
@@ -1533,7 +1541,7 @@ class Client:
         """
 
         response: requests.Response = requests.get(
-            f"{self._config.server.url}/api/tag/{tag_id}", headers=self._headers
+            f"{self._user_config.server.url}/api/tag/{tag_id}", headers=self._headers
         )
 
         json_response = self._get_json_from_response(

--- a/simvue/factory/proxy/remote.py
+++ b/simvue/factory/proxy/remote.py
@@ -28,10 +28,10 @@ class Remote(SimvueBaseClass):
         config: "SimvueConfiguration",
         suppress_errors: bool = True,
     ) -> None:
-        self._config = config
+        self._user_config = config
 
         self._headers: dict[str, str] = {
-            "Authorization": f"Bearer {self._config.server.token}",
+            "Authorization": f"Bearer {self._user_config.server.token}",
             "User-Agent": f"Simvue Python client {__version__}",
         }
         self._headers_mp: dict[str, str] = self._headers | {
@@ -46,7 +46,7 @@ class Remote(SimvueBaseClass):
         logger.debug("Retrieving existing tags")
         try:
             response = get(
-                f"{self._config.server.url}/api/runs/{self._id}", self._headers
+                f"{self._user_config.server.url}/api/runs/{self._id}", self._headers
             )
         except Exception as err:
             self._error(f"Exception retrieving tags: {str(err)}")
@@ -80,7 +80,7 @@ class Remote(SimvueBaseClass):
             logger.debug("Creating folder %s if necessary", data.get("folder"))
             try:
                 response = post(
-                    f"{self._config.server.url}/api/folders",
+                    f"{self._user_config.server.url}/api/folders",
                     self._headers,
                     {"path": data.get("folder")},
                 )
@@ -104,7 +104,9 @@ class Remote(SimvueBaseClass):
         logger.debug('Creating run with data: "%s"', data)
 
         try:
-            response = post(f"{self._config.server.url}/api/runs", self._headers, data)
+            response = post(
+                f"{self._user_config.server.url}/api/runs", self._headers, data
+            )
         except Exception as err:
             self._error(f"Exception creating run: {str(err)}")
             return (None, None)
@@ -143,7 +145,9 @@ class Remote(SimvueBaseClass):
         logger.debug('Updating run with data: "%s"', data)
 
         try:
-            response = put(f"{self._config.server.url}/api/runs", self._headers, data)
+            response = put(
+                f"{self._user_config.server.url}/api/runs", self._headers, data
+            )
         except Exception as err:
             self._error(f"Exception updating run: {err}")
             return None
@@ -172,7 +176,7 @@ class Remote(SimvueBaseClass):
 
         try:
             response = post(
-                f"{self._config.server.url}/api/folders", self._headers, data
+                f"{self._user_config.server.url}/api/folders", self._headers, data
             )
         except Exception as err:
             self._error(f"Exception creating folder: {err}")
@@ -191,7 +195,7 @@ class Remote(SimvueBaseClass):
 
         try:
             response = put(
-                f"{self._config.server.url}/api/folders", self._headers, data
+                f"{self._user_config.server.url}/api/folders", self._headers, data
             )
         except Exception as err:
             self._error(f"Exception setting folder details: {err}")
@@ -223,7 +227,7 @@ class Remote(SimvueBaseClass):
         # Get presigned URL
         try:
             response = post(
-                f"{self._config.server.url}/api/artifacts",
+                f"{self._user_config.server.url}/api/artifacts",
                 self._headers,
                 prepare_for_api(data),
             )
@@ -307,7 +311,7 @@ class Remote(SimvueBaseClass):
                     return None
 
         if storage_id:
-            path = f"{self._config.server.url}/api/runs/{self._id}/artifacts"
+            path = f"{self._user_config.server.url}/api/runs/{self._id}/artifacts"
             data["storage"] = storage_id
 
             try:
@@ -338,7 +342,7 @@ class Remote(SimvueBaseClass):
 
         try:
             response = post(
-                f"{self._config.server.url}/api/alerts", self._headers, data
+                f"{self._user_config.server.url}/api/alerts", self._headers, data
             )
         except Exception as err:
             self._error(f"Got exception when creating an alert: {str(err)}")
@@ -366,7 +370,7 @@ class Remote(SimvueBaseClass):
         data = {"run": self._id, "alert": alert_id, "status": status}
         try:
             response = put(
-                f"{self._config.server.url}/api/alerts/status", self._headers, data
+                f"{self._user_config.server.url}/api/alerts/status", self._headers, data
             )
         except Exception as err:
             self._error(f"Got exception when setting alert state: {err}")
@@ -383,7 +387,7 @@ class Remote(SimvueBaseClass):
         List alerts
         """
         try:
-            response = get(f"{self._config.server.url}/api/alerts", self._headers)
+            response = get(f"{self._user_config.server.url}/api/alerts", self._headers)
         except Exception as err:
             self._error(f"Got exception when listing alerts: {str(err)}")
             return []
@@ -412,7 +416,7 @@ class Remote(SimvueBaseClass):
 
         try:
             response = post(
-                f"{self._config.server.url}/api/metrics",
+                f"{self._user_config.server.url}/api/metrics",
                 self._headers_mp,
                 data,
                 is_json=False,
@@ -440,7 +444,7 @@ class Remote(SimvueBaseClass):
 
         try:
             response = post(
-                f"{self._config.server.url}/api/events",
+                f"{self._user_config.server.url}/api/events",
                 self._headers_mp,
                 data,
                 is_json=False,
@@ -466,7 +470,7 @@ class Remote(SimvueBaseClass):
 
         try:
             response = put(
-                f"{self._config.server.url}/api/runs/heartbeat",
+                f"{self._user_config.server.url}/api/runs/heartbeat",
                 self._headers,
                 {"id": self._id},
             )
@@ -488,7 +492,8 @@ class Remote(SimvueBaseClass):
 
         try:
             response = get(
-                f"{self._config.server.url}/api/runs/{self._id}/abort", self._headers_mp
+                f"{self._user_config.server.url}/api/runs/{self._id}/abort",
+                self._headers_mp,
             )
         except Exception as err:
             self._error(f"Exception retrieving abort status: {str(err)}")

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -404,7 +404,7 @@ class Run:
             run_id: typing.Optional[str] = self._id,
             uuid: str = self._uuid,
         ) -> None:
-            _offline_directory = self.config.offline.cache
+            _offline_directory = self._config.offline.cache
             if not os.path.exists(_offline_directory):
                 logger.error(
                     f"Cannot write to offline directory '{_offline_directory}', directory not found."

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -159,19 +159,19 @@ class Run:
         self._data: dict[str, typing.Any] = {}
         self._step: int = 0
         self._active: bool = False
-        self._config = SimvueConfiguration.fetch()
+        self._user_config = SimvueConfiguration.fetch()
 
         logging.getLogger(self.__class__.__module__).setLevel(
             logging.DEBUG
             if (debug is not None and debug)
-            or (debug is None and self._config.client.debug)
+            or (debug is None and self._user_config.client.debug)
             else logging.INFO
         )
 
         self._aborted: bool = False
         self._resources_metrics_interval: typing.Optional[int] = HEARTBEAT_INTERVAL
         self._headers: dict[str, str] = {
-            "Authorization": f"Bearer {self._config.server.token}"
+            "Authorization": f"Bearer {self._user_config.server.token}"
         }
         self._simvue: typing.Optional[SimvueBaseClass] = None
         self._pid: typing.Optional[int] = 0
@@ -313,7 +313,8 @@ class Run:
         self,
     ) -> typing.Callable[[threading.Event], None]:
         if (
-            self._mode == "online" and (not self._config.server.url or not self._id)
+            self._mode == "online"
+            and (not self._user_config.server.url or not self._id)
         ) or not self._heartbeat_termination_trigger:
             raise RuntimeError("Could not commence heartbeat, run not initialised")
 
@@ -395,7 +396,7 @@ class Run:
         if self._mode == "online" and not self._id:
             raise RuntimeError("Expected identifier for run")
 
-        if not self._config.server.url:
+        if not self._user_config.server.url:
             raise RuntimeError("Cannot commence dispatch, run not initialised")
 
         def _offline_dispatch_callback(
@@ -404,7 +405,7 @@ class Run:
             run_id: typing.Optional[str] = self._id,
             uuid: str = self._uuid,
         ) -> None:
-            _offline_directory = self._config.offline.cache
+            _offline_directory = self._user_config.offline.cache
             if not os.path.exists(_offline_directory):
                 logger.error(
                     f"Cannot write to offline directory '{_offline_directory}', directory not found."
@@ -431,7 +432,7 @@ class Run:
         def _online_dispatch_callback(
             buffer: list[typing.Any],
             category: str,
-            url: str = self._config.server.url,
+            url: str = self._user_config.server.url,
             run_id: typing.Optional[str] = self._id,
             headers: dict[str, str] = self._headers,
         ) -> None:
@@ -634,11 +635,11 @@ class Run:
             )
             return True
 
-        description = description or self._config.run.description
-        tags = (tags or []) + (self._config.run.tags or [])
-        folder = folder or self._config.run.folder
-        name = name or self._config.run.name
-        metadata = (metadata or {}) | (self._config.run.metadata or {})
+        description = description or self._user_config.run.description
+        tags = (tags or []) + (self._user_config.run.tags or [])
+        folder = folder or self._user_config.run.folder
+        name = name or self._user_config.run.name
+        metadata = (metadata or {}) | (self._user_config.run.metadata or {})
 
         self._term_color = not no_color
 
@@ -651,7 +652,7 @@ class Run:
             self._error("invalid mode specified, must be online, offline or disabled")
             return False
 
-        if not self._config.server.token or not self._config.server.url:
+        if not self._user_config.server.token or not self._user_config.server.url:
             self._error(
                 "Unable to get URL and token from environment variables or config file"
             )
@@ -707,7 +708,7 @@ class Run:
             name=self._name,
             uniq_id=self._uuid,
             mode=self._mode,
-            config=self._config,
+            config=self._user_config,
             suppress_errors=self._suppress_errors,
         )
         name, self._id = self._simvue.create_run(data)
@@ -730,7 +731,7 @@ class Run:
                 fg="green" if self._term_color else None,
             )
             click.secho(
-                f"[simvue] Monitor in the UI at {self._config.server.url}/dashboard/runs/run/{self._id}",
+                f"[simvue] Monitor in the UI at {self._user_config.server.url}/dashboard/runs/run/{self._id}",
                 bold=self._term_color,
                 fg="green" if self._term_color else None,
             )
@@ -938,7 +939,7 @@ class Run:
 
         self._id = run_id
         self._simvue = Simvue(
-            self._name, self._id, self._mode, self._config, self._suppress_errors
+            self._name, self._id, self._mode, self._user_config, self._suppress_errors
         )
         self._start(reconnect=True)
 

--- a/tests/refactor/conftest.py
+++ b/tests/refactor/conftest.py
@@ -113,7 +113,7 @@ def setup_test_run(run: sv_run.Run, create_objects: bool, request: pytest.Fixtur
         TEST_DATA["metrics"] = ("metric_counter", "metric_val")
     TEST_DATA["run_id"] = run._id
     TEST_DATA["run_name"] = run._name
-    TEST_DATA["url"] = run._config.server.url
+    TEST_DATA["url"] = run._user_config.server.url
     TEST_DATA["headers"] = run._headers
     TEST_DATA["pid"] = run._pid
     TEST_DATA["resources_metrics_interval"] = run._resources_metrics_interval


### PR DESCRIPTION
# Fix use of `config` instead of `_config` in offline directory retrieval

**Issue:** N/A

**Python Version(s) Tested:** 3.13.0

**Operating System(s):** Ubuntu 24.10

## 📝 Summary

The following code is incorrect:
https://github.com/simvue-io/python-api/blob/2939263e422aa783cfe5d0eef9897c82947e82cc/simvue/run.py#L407

Use of the member function `config` instead of the `_config` attribute.

## 🔍 Diagnosis

Running tests revealed this.

## ✔️ Checklist
- [x] Unit and integration tests passing.
- [x] Pre-commit hooks passing.
- [x] Quality checks passing.
