### PR TITLE
Fix incorrect assumption of `test_set_folder_details` assumption of tag ordering

### DIFF
--- a/tests/functional/test_run_class.py
+++ b/tests/functional/test_run_class.py
@@ -437,7 +437,7 @@ def test_set_folder_details(request: pytest.FixtureRequest) -> None:
         run.set_folder_details(path=folder_name, tags=tags, description=description)
 
     client = sv_cl.Client()
-    assert (folder := client.get_folders(filters=[f"path == {folder_name}"])[0])["tags"] == tags
+    assert sorted((folder := client.get_folders(filters=[f"path == {folder_name}"])[0])["tags"]) == sorted(tags)
     assert folder["description"] == description
 
 


### PR DESCRIPTION
This fixes https://github.com/simvue-io/python-api/issues/596