### PR TITLE
Using `reconnect()` incorrectly results in a `Run is not active` error

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -1518,7 +1518,7 @@ class Run:
         bool
             if status update was successful
         """
-        if not self._active or not self._name:
+        if not self._active:
             self._error("Run is not active")
             return False
 


### PR DESCRIPTION
# Using `reconnect()` incorrectly results in a `Run is not active` error

**Issue:** [Link to the issue relating to this bug.](https://github.com/simvue-io/python-api/issues/613)

**Python Version(s) Tested:** 3.10.12

**Operating System(s):** MacOS

## 📝 Summary

`reconnect()` is broken. It looks like it was never migrated from v1 to v2 due to a check for the existence of a run name rather than id.

## 🔍 Diagnosis

The bug can be reproduced by this:
```
from simvue import Run

if __name__ == "__main__":
    with Run() as run:
        run.init(running=False)

        run_id = run.id

    with Run() as run:
        run.reconnect(run_id)
```

## 🔄 Changes

Incorrect check for value of `self._name` removed.

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [ ] Pre-commit hooks passing.
- [ ] Quality checks passing.
