### PR TITLE
Fix incorrect file open type when uploading `requirements.txt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+## Unreleased
+* Fixed bug with `requirements.txt` metadata read.
 ## [v1.1.2](https://github.com/simvue-io/client/releases/tag/v1.1.2) - 2024-11-06
 
 * Fix bug in offline mode directory retrieval.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "simvue"
-version = "1.1.2"
+version = "1.1.3"
 description = "Simulation tracking and monitoring"
 authors = ["Simvue Development Team <info@simvue.io>"]
 license = "Apache v2"

--- a/simvue/metadata.py
+++ b/simvue/metadata.py
@@ -82,7 +82,7 @@ def _python_env(repository: pathlib.Path) -> dict[str, typing.Any]:
     req_meta: dict[str, str] = {}
 
     if (reqfile := pathlib.Path(repository).joinpath("requirements.txt")).exists():
-        with reqfile.open("w") as in_req:
+        with reqfile.open() as in_req:
             requirement_lines = in_req.readlines()
             req_meta = {}
 


### PR DESCRIPTION
# Fix incorrect use of `"w"` when reading `requirements.txt`

**Issue:** https://github.com/simvue-io/python-api/issues/602

**Python Version(s) Tested:** 3.13

**Operating System(s):** Ubuntu 24.10

## 📝 Summary

Use of `"w"` when opening the requirements file for reading.

## 🔍 Diagnosis

Identified from running of Simvue within projects which contain such a requirements file.

## 🔄 Changes

Removed specified file opening type.

## ✔️ Checklist
- [x] Unit and integration tests passing.
- [x] Pre-commit hooks passing.
- [x] Quality checks passing.
