### PR TITLE
Checking for existence of self._name is incorrect in v2

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -1525,7 +1525,7 @@ class Run:
         bool
             if status update was successful
         """
-        if not self._active or not self._name:
+        if not self._active:
             self._error("Run is not active")
             return False
 


### PR DESCRIPTION
Fixing `reconnect()` yet again.