### PR TITLE
Tenant class refactor

### DIFF
--- a/simvue/api/objects/administrator/tenant.py
+++ b/simvue/api/objects/administrator/tenant.py
@@ -22,7 +22,7 @@ class Tenant(SimvueObject):
     ) -> Self:
         _tenant = Tenant(
             name=name,
-            enabled=enabled,
+            is_enabled=enabled,
             max_request_rate=max_request_rate,
             max_runs=max_runs,
             max_data_volume=max_data_volume,

--- a/simvue/api/objects/administrator/tenant.py
+++ b/simvue/api/objects/administrator/tenant.py
@@ -10,8 +10,25 @@ from simvue.api.objects.base import write_only, SimvueObject, staging_check
 class Tenant(SimvueObject):
     @classmethod
     @pydantic.validate_call
-    def new(cls, *, name: str, enabled: bool = True, offline: bool = False) -> Self:
-        _tenant = Tenant(name=name, enabled=enabled, offline=offline, _read_only=False)
+    def new(
+        cls,
+        *,
+        name: str,
+        is_enabled: bool = True,
+        max_request_rate: int = 0,
+        max_runs: int = 0,
+        max_data_volume: int = 0,
+        offline: bool = False,
+    ) -> Self:
+        _tenant = Tenant(
+            name=name,
+            is_enabled=is_enabled,
+            max_request_rate=max_request_rate,
+            max_runs=max_runs,
+            max_data_volume=max_data_volume,
+            offline=offline,
+            _read_only=False,
+        )
         _tenant.offline_mode(offline)
         return _tenant  # type: ignore
 
@@ -20,15 +37,61 @@ class Tenant(SimvueObject):
         """Retrieve the name of the tenant"""
         return self._get_attribute("name")
 
-    @property
-    @staging_check
-    def enabled(self) -> bool:
-        """Retrieve if tenant is enabled"""
-        return self._get_attribute("enabled")
-
-    @enabled.setter
+    @name.setter
     @write_only
     @pydantic.validate_call
-    def enabled(self, enabled: str) -> None:
+    def name(self, name: str) -> None:
+        """Change name of tenant"""
+        self._staging["name"] = name
+
+    @property
+    @staging_check
+    def is_enabled(self) -> bool:
+        """Retrieve if tenant is enabled"""
+        return self._get_attribute("is_enabled")
+
+    @is_enabled.setter
+    @write_only
+    @pydantic.validate_call
+    def is_enabled(self, is_enabled: str) -> None:
         """Enable/disable tenant"""
-        self._staging["enabled"] = enabled
+        self._staging["is_enabled"] = is_enabled
+
+    @property
+    @staging_check
+    def max_request_rate(self) -> bool:
+        """Retrieve the tenant's maximum request rate"""
+        return self._get_attribute("max_request_rate")
+
+    @max_request_rate.setter
+    @write_only
+    @pydantic.validate_call
+    def max_request_rate(self, max_request_rate: str) -> None:
+        """Update tenant's maximum request rate"""
+        self._staging["max_request_rate"] = max_request_rate
+
+    @property
+    @staging_check
+    def max_runs(self) -> bool:
+        """Retrieve the tenant's maximum runs"""
+        return self._get_attribute("max_runs")
+
+    @max_runs.setter
+    @write_only
+    @pydantic.validate_call
+    def max_runs(self, max_runs: str) -> None:
+        """Update tenant's maximum runs"""
+        self._staging["max_runs"] = max_runs
+
+    @property
+    @staging_check
+    def max_data_volume(self) -> bool:
+        """Retrieve the tenant's maximum data volume"""
+        return self._get_attribute("max_data_volume")
+
+    @max_data_volume.setter
+    @write_only
+    @pydantic.validate_call
+    def max_data_volume(self, max_data_volume: str) -> None:
+        """Update tenant's maximum data volume"""
+        self._staging["max_data_volume"] = max_data_volume

--- a/simvue/api/objects/administrator/tenant.py
+++ b/simvue/api/objects/administrator/tenant.py
@@ -14,7 +14,7 @@ class Tenant(SimvueObject):
         cls,
         *,
         name: str,
-        is_enabled: bool = True,
+        enabled: bool = True,
         max_request_rate: int = 0,
         max_runs: int = 0,
         max_data_volume: int = 0,
@@ -22,7 +22,7 @@ class Tenant(SimvueObject):
     ) -> Self:
         _tenant = Tenant(
             name=name,
-            is_enabled=is_enabled,
+            enabled=enabled,
             max_request_rate=max_request_rate,
             max_runs=max_runs,
             max_data_volume=max_data_volume,

--- a/simvue/api/objects/administrator/tenant.py
+++ b/simvue/api/objects/administrator/tenant.py
@@ -46,16 +46,16 @@ class Tenant(SimvueObject):
 
     @property
     @staging_check
-    def is_enabled(self) -> bool:
+    def enabled(self) -> bool:
         """Retrieve if tenant is enabled"""
         return self._get_attribute("is_enabled")
 
-    @is_enabled.setter
+    @enabled.setter
     @write_only
     @pydantic.validate_call
-    def is_enabled(self, is_enabled: bool) -> None:
+    def enabled(self, enabled: bool) -> None:
         """Enable/disable tenant"""
-        self._staging["is_enabled"] = is_enabled
+        self._staging["is_enabled"] = enabled
 
     @property
     @staging_check

--- a/simvue/api/objects/administrator/tenant.py
+++ b/simvue/api/objects/administrator/tenant.py
@@ -53,45 +53,45 @@ class Tenant(SimvueObject):
     @is_enabled.setter
     @write_only
     @pydantic.validate_call
-    def is_enabled(self, is_enabled: str) -> None:
+    def is_enabled(self, is_enabled: bool) -> None:
         """Enable/disable tenant"""
         self._staging["is_enabled"] = is_enabled
 
     @property
     @staging_check
-    def max_request_rate(self) -> bool:
+    def max_request_rate(self) -> int:
         """Retrieve the tenant's maximum request rate"""
         return self._get_attribute("max_request_rate")
 
     @max_request_rate.setter
     @write_only
     @pydantic.validate_call
-    def max_request_rate(self, max_request_rate: str) -> None:
+    def max_request_rate(self, max_request_rate: int) -> None:
         """Update tenant's maximum request rate"""
         self._staging["max_request_rate"] = max_request_rate
 
     @property
     @staging_check
-    def max_runs(self) -> bool:
+    def max_runs(self) -> int:
         """Retrieve the tenant's maximum runs"""
         return self._get_attribute("max_runs")
 
     @max_runs.setter
     @write_only
     @pydantic.validate_call
-    def max_runs(self, max_runs: str) -> None:
+    def max_runs(self, max_runs: int) -> None:
         """Update tenant's maximum runs"""
         self._staging["max_runs"] = max_runs
 
     @property
     @staging_check
-    def max_data_volume(self) -> bool:
+    def max_data_volume(self) -> int:
         """Retrieve the tenant's maximum data volume"""
         return self._get_attribute("max_data_volume")
 
     @max_data_volume.setter
     @write_only
     @pydantic.validate_call
-    def max_data_volume(self, max_data_volume: str) -> None:
+    def max_data_volume(self, max_data_volume: int) -> None:
         """Update tenant's maximum data volume"""
         self._staging["max_data_volume"] = max_data_volume


### PR DESCRIPTION
@kzscisoft just want to check this looks as you expect now with server v3?

Also there must be a better way of defining multiple sets of getters and setters than copy pasting them as I have done here... Could do something like this?

```py
def create_property(name: str, type_hint: Type) -> property:
    @staging_check
    def getter(self) -> type_hint:
        return self._get_attribute(name)

    @write_only
    @pydantic.validate_call
    def setter(self, value: type_hint) -> None:
        self._staging[name] = value

    getter.__name__ = name
    setter.__name__ = name

    return property(getter, setter)

class Tenant(SimvueObject):
    ...
    name: create_property("name", str)
    is_enabled = create_property("is_enabled", bool)
```

The issue is I dont think variables as type hints are allowed (or at least thats what pylint says), might make the code a bit less readable too... But would prevent copy/paste errors... Any other suggestions?