### PR TITLE
Hotfix: Finding toml files

### DIFF
--- a/simvue/utilities.py
+++ b/simvue/utilities.py
@@ -50,16 +50,17 @@ def find_first_instance_of_file(
     if isinstance(file_names, str):
         file_names = [file_names]
 
-    for root, _, files in os.walk(os.getcwd(), topdown=False):
-        for file_name in file_names:
-            if file_name in files:
-                return pathlib.Path(root).joinpath(file_name)
+    for file_name in file_names:
+        _user_file = pathlib.Path.cwd().joinpath(file_name)
+        if _user_file.exists():
+            return _user_file
 
     # If the user is running on different mounted volume or outside
     # of their user space then the above will not return the file
     if check_user_space:
         for file_name in file_names:
-            if os.path.exists(_user_file := pathlib.Path.home().joinpath(file_name)):
+            _user_file = pathlib.Path.home().joinpath(file_name)
+            if _user_file.exists():
                 return _user_file
 
     return None


### PR DESCRIPTION
Currently simvue looks through *all subdirectories* of current working dir in search of a `simvue.toml` file before trying `$HOME` - lets not do this in case the users CWD has huge numbers of files contained within...

Changed to just check top level of `cwd`, then top level of `home` dir

Closes #680 