### PR TITLE
Bug fixes for 2.0.0a3

### DIFF
--- a/simvue/api/objects/base.py
+++ b/simvue/api/objects/base.py
@@ -171,6 +171,7 @@ class SimvueObject(abc.ABC):
             {
                 "Authorization": f"Bearer {self._user_config.server.token.get_secret_value()}",
                 "User-Agent": _user_agent or f"Simvue Python client {__version__}",
+                "Accept-Encoding": "gzip",
             }
             if not self._offline
             else {}

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -84,7 +84,8 @@ class Client:
                 logger.warning(f"No {label} specified")
 
         self._headers: dict[str, str] = {
-            "Authorization": f"Bearer {self._user_config.server.token.get_secret_value()}"
+            "Authorization": f"Bearer {self._user_config.server.token.get_secret_value()}",
+            "Accept-Encoding": "gzip",
         }
 
     @prettify_pydantic

--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -347,7 +347,7 @@ class Executor:
             # This is so that if a process incorrectly reports its return code,
             # the user can manually set the correct status depending on logs etc.
             _alert = Alert(identifier=self._alert_ids[proc_id])
-            _is_set = _alert.get_status(run_id=self._id)
+            _is_set = _alert.get_status(run_id=self._runner._id)
 
             if process.returncode != 0:
                 # If the process fails then purge the dispatcher event queue

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -1657,6 +1657,11 @@ class Run:
         names = names or []
 
         if names and not ids:
+            if self._user_config.run.mode == "offline":
+                self._error(
+                    "Cannot retrieve alerts based on names in offline mode - please use IDs instead."
+                )
+                return False
             try:
                 if alerts := Alert.get(offline=self._user_config.run.mode == "offline"):
                     ids += [id for id, alert in alerts if alert.name in names]
@@ -1955,6 +1960,12 @@ class Run:
 
         if (identifier and name) or (not identifier and not name):
             self._error("Please specify alert to update either by ID or by name.")
+            return False
+
+        if self._user_config.run.mode == "offline":
+            self._error(
+                "Cannot retrieve alerts based on names in offline mode - please use IDs instead."
+            )
             return False
 
         if name:

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -186,7 +186,8 @@ class Run:
         )
         self._headers: dict[str, str] = (
             {
-                "Authorization": f"Bearer {self._user_config.server.token.get_secret_value()}"
+                "Authorization": f"Bearer {self._user_config.server.token.get_secret_value()}",
+                "Accept-Encoding": "gzip",
             }
             if mode != "offline"
             else {}

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -355,8 +355,9 @@ class Run:
 
             if self._resources_metrics_interval:
                 self._add_metrics_to_dispatch(
-                    self._get_sysinfo(interval=1), join_on_fail=False
+                    self._get_sysinfo(interval=1), join_on_fail=False, step=0
                 )
+                res_step = 1
 
             while not heartbeat_trigger.is_set():
                 time.sleep(0.1)
@@ -371,9 +372,10 @@ class Run:
                         # join would be called on this thread and a thread cannot
                         # join itself!
                         self._add_metrics_to_dispatch(
-                            self._get_sysinfo(), join_on_fail=False
+                            self._get_sysinfo(), join_on_fail=False, step=res_step
                         )
                         last_res_metric_call = res_time
+                        res_step += 1
 
                 if time.time() - last_heartbeat < self._heartbeat_interval:
                     continue


### PR DESCRIPTION
Bug fixes for 2.0.0 alpha 3. Includes:

- Adds accepts gzip encoding to headers, fixes #730 
- Adds PID to sender lock file so that that can be compared to running PIDs when a sender starts, to allow for senders to recover from a crash, fixes #736 
- Dont overwrite user's process alert status if already set on process ending
- Throw error if user tries to specify alert name in log or get alerts, see #739 
- Fix processes property in executor and run to reuse the same Process objects wherever possible so that CPU metrics are accurate, fixes #727 
