### PR TITLE
Add validation error is string handling

### DIFF
--- a/simvue/utilities.py
+++ b/simvue/utilities.py
@@ -92,6 +92,13 @@ def parse_validation_response(
 
     out: list[list[str]] = []
 
+    if isinstance(issues, str):
+        return tabulate.tabulate(
+            ["Unknown", "N/A", issues],
+            headers=["Type", "Location", "Message"],
+            tablefmt="fancy_grid",
+        )
+
     for issue in issues:
         obj_type: str = issue["type"]
         location: list[str] = issue["loc"]


### PR DESCRIPTION
# Fix Server Validation Error String Handling

**Issue:** N/A

**Python Version(s) Tested:** 3.13

**Operating System(s):** Ubuntu 24.10

## 📝 Summary

Addresses case whereby the server sends a validation error which is a string, not a dict.

## 🔍 Diagnosis

`IndexError` when printing the validation error using the "prettify" methods.

## 🔄 Changes

Added logic for handling if the validation error is a string not a dict.

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [ ] Pre-commit hooks passing.
- [ ] Quality checks passing.
