### PR TITLE
Add `read_only` parameter to `Client.get_folder`

### DIFF
--- a/simvue/client.py
+++ b/simvue/client.py
@@ -628,7 +628,9 @@ class Client:
     @prettify_pydantic
     @pydantic.validate_call
     def get_folder(
-        self, folder_path: typing.Annotated[str, pydantic.Field(pattern=FOLDER_REGEX)]
+        self,
+        folder_path: typing.Annotated[str, pydantic.Field(pattern=FOLDER_REGEX)],
+        read_only: bool = True,
     ) -> Folder | None:
         """Retrieve a folder by identifier
 
@@ -637,6 +639,10 @@ class Client:
         folder_path : str
             the path of the folder to retrieve on the server.
             Paths are prefixed with `/`
+        read_only : bool, optional
+            whether the returned object should be editable or not,
+            default is True, the object is a cached copy of data
+            from the server.
 
         Returns
         -------
@@ -654,6 +660,8 @@ class Client:
 
         try:
             _, _folder = next(_folders)
+            if not read_only:
+                _folder.read_only(read_only)
             return _folder
         except StopIteration:
             return None


### PR DESCRIPTION
# Re-add ability to set folders details to `Client`

**Issue:** https://github.com/simvue-io/python-api/issues/480

**Python Version(s) Tested:** 3.13

**Operating System(s):** Ubuntu 24.10

**Documentation PR:** N/A

## 📝 Summary

Adds `read_only` parameter which has a default value of `True` to `Client.get_folder` allowing the user to update the folder details.

## 🔄 Changes

Addition of new parameter.

## ✔️ Checklist
- [x] Unit and integration tests passing.
- [x] Pre-commit hooks passing.
- [x] Quality checks passing.
- [ ] Updated the [documentation](https://github.com/simvue-io/docs).
