### PR TITLE
Fix Ecoclient Units

### DIFF
--- a/simvue/api/objects/events.py
+++ b/simvue/api/objects/events.py
@@ -51,7 +51,7 @@ class Events(SimvueObject):
         _class_instance = cls(_read_only=True, _local=True)
         _count: int = 0
 
-        for response in cls._get_all_objects(offset, run=run_id, **kwargs):
+        for response in cls._get_all_objects(offset, count=count, run=run_id, **kwargs):
             if (_data := response.get("data")) is None:
                 raise RuntimeError(
                     f"Expected key 'data' for retrieval of {_class_instance.__class__.__name__.lower()}s"

--- a/simvue/api/request.py
+++ b/simvue/api/request.py
@@ -305,19 +305,15 @@ def get_paginated(
     _offset: int = offset or 0
 
     while (
-        (
-            _response := get(
-                url=url,
-                headers=headers,
-                params=(params or {})
-                | {"count": count or MAX_ENTRIES_PER_PAGE, "start": _offset},
-                timeout=timeout,
-                json=json,
-            )
+        _response := get(
+            url=url,
+            headers=headers,
+            params=(params or {})
+            | {"count": count or MAX_ENTRIES_PER_PAGE, "start": _offset},
+            timeout=timeout,
+            json=json,
         )
-        .json()
-        .get("data")
-    ):
+    ).json():
         yield _response
         _offset += MAX_ENTRIES_PER_PAGE
 

--- a/simvue/api/request.py
+++ b/simvue/api/request.py
@@ -303,7 +303,6 @@ def get_paginated(
         server response
     """
     _offset: int = offset or 0
-
     while (
         _response := get(
             url=url,
@@ -317,5 +316,7 @@ def get_paginated(
         yield _response
         _offset += MAX_ENTRIES_PER_PAGE
 
-        if count and _offset > count:
+        if (count and _offset > count) or (
+            _response.json().get("count", 0) < (count or MAX_ENTRIES_PER_PAGE)
+        ):
             break

--- a/simvue/api/request.py
+++ b/simvue/api/request.py
@@ -316,7 +316,5 @@ def get_paginated(
         yield _response
         _offset += MAX_ENTRIES_PER_PAGE
 
-        if (count and _offset > count) or (
-            _response.json().get("count", 0) < (count or MAX_ENTRIES_PER_PAGE)
-        ):
+        if (count and _offset > count) or (_response.json().get("count", 0) < _offset):
             break

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -835,7 +835,8 @@ class Client:
 
         _args = {"filters": json.dumps(run_filters)} if run_filters else {}
 
-        _run_data = dict(Run.get(**_args))
+        if not run_ids:
+            _run_data = dict(Run.get(**_args))
 
         if not (
             _run_metrics := self._get_run_metrics_from_server(
@@ -853,7 +854,8 @@ class Client:
             )
         if use_run_names:
             _run_metrics = {
-                _run_data[key].name: _run_metrics[key] for key in _run_metrics.keys()
+                Run(identifier=key).name: _run_metrics[key]
+                for key in _run_metrics.keys()
             }
         return parse_run_set_metrics(
             _run_metrics,

--- a/simvue/config/user.py
+++ b/simvue/config/user.py
@@ -200,6 +200,7 @@ class SimvueConfiguration(pydantic.BaseModel):
             _default_dir = _config_dict["offline"].get(
                 "cache", DEFAULT_OFFLINE_DIRECTORY
             )
+        pathlib.Path(_default_dir).mkdir(parents=True, exist_ok=True)
 
         _config_dict["offline"]["cache"] = _default_dir
 

--- a/simvue/eco/api_client.py
+++ b/simvue/eco/api_client.py
@@ -77,7 +77,7 @@ class APIClient(pydantic.BaseModel):
         co2_api_endpoint : str
             endpoint for CO2 signal API
         co2_api_token: str
-            RECOMMENDED. The API token for the CO2 Signal API, default is None.
+            The API token for the ElectricityMaps API, default is None.
         timeout : int
             timeout for API
         """
@@ -85,10 +85,7 @@ class APIClient(pydantic.BaseModel):
         self._logger = logging.getLogger(self.__class__.__name__)
 
         if not self.co2_api_token:
-            self._logger.warning(
-                "⚠️  No API token provided for CO2 Signal, "
-                "use of a token is strongly recommended."
-            )
+            raise ValueError("API token is required for ElectricityMaps API.")
 
         self._get_user_location_info()
 

--- a/simvue/eco/config.py
+++ b/simvue/eco/config.py
@@ -8,10 +8,6 @@ Configuration file extension for configuring the Simvue Eco sub-module.
 __date__ = "2025-03-06"
 
 import pydantic
-import pathlib
-import os
-
-from simvue.config.files import DEFAULT_OFFLINE_DIRECTORY
 
 
 class EcoConfig(pydantic.BaseModel):
@@ -25,30 +21,13 @@ class EcoConfig(pydantic.BaseModel):
         the TDP for the CPU
     gpu_thermal_design_power: int | None, optional
         the TDP for each GPU
-    local_data_directory: str, optional
-        the directory to store local data, default is Simvue offline directory
     """
 
     co2_signal_api_token: pydantic.SecretStr | None = None
     cpu_thermal_design_power: pydantic.PositiveInt | None = None
     cpu_n_cores: pydantic.PositiveInt | None = None
     gpu_thermal_design_power: pydantic.PositiveInt | None = None
-    local_data_directory: pydantic.DirectoryPath | None = pydantic.Field(
-        None, validate_default=True
-    )
     intensity_refresh_interval: pydantic.PositiveInt | str | None = pydantic.Field(
         default="1 hour", gt=2 * 60
     )
     co2_intensity: float | None = None
-
-    @pydantic.field_validator("local_data_directory", mode="before", check_fields=True)
-    @classmethod
-    def check_local_data_env(
-        cls, local_data_directory: pathlib.Path | None
-    ) -> pathlib.Path:
-        if _data_directory := os.environ.get("SIMVUE_ECO_DATA_DIRECTORY"):
-            return pathlib.Path(_data_directory)
-        if not local_data_directory:
-            local_data_directory = pathlib.Path(DEFAULT_OFFLINE_DIRECTORY)
-            local_data_directory.mkdir(exist_ok=True, parents=True)
-        return local_data_directory

--- a/simvue/eco/config.py
+++ b/simvue/eco/config.py
@@ -37,7 +37,7 @@ class EcoConfig(pydantic.BaseModel):
         None, validate_default=True
     )
     intensity_refresh_interval: pydantic.PositiveInt | str | None = pydantic.Field(
-        default="1 day", gt=2 * 60
+        default="1 hour", gt=2 * 60
     )
     co2_intensity: float | None = None
 

--- a/simvue/eco/emissions_monitor.py
+++ b/simvue/eco/emissions_monitor.py
@@ -246,7 +246,7 @@ class CO2Monitor(pydantic.BaseModel):
                     "No CO2 emission data recorded as no CO2 intensity value "
                     "has been provided and there is no local intensity data available."
                 )
-                return
+                return False
 
             if self._client:
                 _country_code = self._client.country_code
@@ -285,6 +285,7 @@ class CO2Monitor(pydantic.BaseModel):
             f"📝 For process '{process_id}', in interval {measure_interval}, recorded: CPU={_process.cpu_percentage:.2f}%, "
             f"Power={_process.power_usage:.2f}kW, Energy = {_process.energy_delta}kWh, CO2={_process.co2_delta:.2e}kg"
         )
+        return True
 
     def simvue_metrics(self) -> dict[str, float]:
         """Retrieve metrics to send to Simvue server."""

--- a/simvue/eco/emissions_monitor.py
+++ b/simvue/eco/emissions_monitor.py
@@ -108,6 +108,15 @@ class CO2Monitor(pydantic.BaseModel):
         """
         _logger = logging.getLogger(self.__class__.__name__)
 
+        if not (
+            kwargs.get("co2_intensity")
+            or kwargs.get("co2_signal_api_token")
+            or kwargs.get("offline")
+        ):
+            raise ValueError(
+                "ElectricityMaps API token or hardcoeded CO2 intensity value is required for emissions tracking."
+            )
+
         if not isinstance(kwargs.get("thermal_design_power_per_cpu"), float):
             kwargs["thermal_design_power_per_cpu"] = 80.0
             _logger.warning(

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -1084,7 +1084,7 @@ class Run:
                     self._emissions_monitor = CO2Monitor(
                         intensity_refresh_interval=None,
                         co2_intensity=self._user_config.eco.co2_intensity,
-                        local_data_directory=self._user_config.eco.local_data_directory,
+                        local_data_directory=self._user_config.offline.cache,
                         co2_signal_api_token=None,
                         thermal_design_power_per_cpu=self._user_config.eco.cpu_thermal_design_power,
                         thermal_design_power_per_gpu=self._user_config.eco.gpu_thermal_design_power,
@@ -1093,7 +1093,7 @@ class Run:
                 else:
                     self._emissions_monitor = CO2Monitor(
                         intensity_refresh_interval=self._user_config.eco.intensity_refresh_interval,
-                        local_data_directory=self._user_config.eco.local_data_directory,
+                        local_data_directory=self._user_config.offline.cache,
                         co2_signal_api_token=self._user_config.eco.co2_signal_api_token,
                         co2_intensity=self._user_config.eco.co2_intensity,
                         thermal_design_power_per_cpu=self._user_config.eco.cpu_thermal_design_power,

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -374,7 +374,7 @@ class Run:
         # For the first emissions metrics reading, the time interval to use
         # Is the time since the run started, otherwise just use the time between readings
         if self._emissions_monitor:
-            self._emissions_monitor.estimate_co2_emissions(
+            _estimated = self._emissions_monitor.estimate_co2_emissions(
                 process_id=f"{self._name}",
                 cpu_percent=_current_system_measure.cpu_percent,
                 measure_interval=(time.time() - self._start_time)
@@ -382,11 +382,12 @@ class Run:
                 else self._system_metrics_interval,
                 gpu_percent=_current_system_measure.gpu_percent,
             )
-            self._add_metrics_to_dispatch(
-                self._emissions_monitor.simvue_metrics(),
-                join_on_fail=False,
-                step=system_metrics_step,
-            )
+            if _estimated:
+                self._add_metrics_to_dispatch(
+                    self._emissions_monitor.simvue_metrics(),
+                    join_on_fail=False,
+                    step=system_metrics_step,
+                )
 
     def _create_heartbeat_callback(
         self,

--- a/simvue/sender.py
+++ b/simvue/sender.py
@@ -245,7 +245,6 @@ def sender(
     # refreshes the CO2 intensity value if required. No emission metrics
     # will be taken by the sender itself, values are assumed to be recorded
     # by any offline runs being sent.
-
     if _user_config.metrics.enable_emission_metrics:
         CO2Monitor(
             thermal_design_power_per_gpu=None,

--- a/simvue/sender.py
+++ b/simvue/sender.py
@@ -151,7 +151,6 @@ def sender(
     max_workers: int = 5,
     threading_threshold: int = 10,
     objects_to_upload: list[str] = UPLOAD_ORDER,
-    co2_intensity_refresh: int | None | str = None,
 ) -> dict[str, str]:
     """Send data from a local cache directory to the Simvue server.
 
@@ -165,9 +164,6 @@ def sender(
         The number of cached files above which threading will be used
     objects_to_upload : list[str]
         Types of objects to upload, by default uploads all types of objects present in cache
-    co2_intensity_refresh: int | None | str
-        the refresh interval for the CO2 intensity value, if None use config value if available,
-        else do not refresh.
 
     Returns
     -------
@@ -250,16 +246,13 @@ def sender(
     # will be taken by the sender itself, values are assumed to be recorded
     # by any offline runs being sent.
 
-    if (
-        _refresh_interval := co2_intensity_refresh
-        or _user_config.eco.intensity_refresh_interval
-    ):
+    if _user_config.metrics.enable_emission_metrics:
         CO2Monitor(
             thermal_design_power_per_gpu=None,
             thermal_design_power_per_cpu=None,
             local_data_directory=cache_dir,
-            intensity_refresh_interval=_refresh_interval,
-            co2_intensity=co2_intensity_refresh or _user_config.eco.co2_intensity,
+            intensity_refresh_interval=_user_config.eco.intensity_refresh_interval,
+            co2_intensity=_user_config.eco.co2_intensity,
             co2_signal_api_token=_user_config.eco.co2_signal_api_token,
         ).check_refresh()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,16 @@ def clear_out_files() -> None:
 
     for file_obj in out_files:
         file_obj.unlink()
-
-
+        
+@pytest.fixture(autouse=True)
+def offline_cache_setup(monkeypatch: monkeypatch.MonkeyPatch):
+    # Will be executed before the test
+    cache_dir = tempfile.TemporaryDirectory()
+    monkeypatch.setenv("SIMVUE_OFFLINE_DIRECTORY", cache_dir.name)
+    yield cache_dir
+    # Will be executed after the test
+    cache_dir.cleanup()
+    
 @pytest.fixture
 def mock_co2_signal(monkeypatch: monkeypatch.MonkeyPatch) -> dict[str, dict | str]:
     _mock_data = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,15 +303,3 @@ def setup_test_run(run: sv_run.Run, create_objects: bool, request: pytest.Fixtur
     TEST_DATA["alert_ids"] = _alert_ids
 
     return TEST_DATA
-
-
-@pytest.fixture
-def offline_test() -> pathlib.Path:
-    with tempfile.TemporaryDirectory() as tempd:
-        _tempdir = pathlib.Path(tempd)
-        _cache_dir = _tempdir.joinpath(".simvue")
-        _cache_dir.mkdir(exist_ok=True)
-        os.environ["SIMVUE_OFFLINE_DIRECTORY"] = f"{_cache_dir}"
-        assert sv_cfg.SimvueConfiguration.fetch().offline.cache == _cache_dir
-        yield _tempdir
-

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -56,35 +56,35 @@ def test_config_setup(
         if use_file:
             if use_file == "pyproject.toml":
                 _lines_ppt: str = f"""
-[tool.poetry]
-name = "simvue_testing"
-version = "0.1.0"
-description = "A dummy test project"
+                    [tool.poetry]
+                    name = "simvue_testing"
+                    version = "0.1.0"
+                    description = "A dummy test project"
 
-[tool.simvue.run]
-description = "{_description_ppt}"
-folder = "{_folder_ppt}"
-tags = {_tags_ppt}
-"""
+                    [tool.simvue.run]
+                    description = "{_description_ppt}"
+                    folder = "{_folder_ppt}"
+                    tags = {_tags_ppt}
+                    """
                 with open((_ppt_file := pathlib.Path(temp_d).joinpath("pyproject.toml")), "w") as out_f:
                     out_f.write(_lines_ppt)
             with open(_config_file := pathlib.Path(temp_d).joinpath("simvue.toml"), "w") as out_f:
                 _lines: str = f"""
-[server]
-url = "{_url}"
-token = "{_token}"
+                    [server]
+                    url = "{_url}"
+                    token = "{_token}"
 
-[offline]
-cache = "{temp_d}"
-"""
+                    [offline]
+                    cache = "{temp_d}"
+                    """
 
                 if use_file == "extended":
                     _lines += f"""
-[run]
-description = "{_description}"
-folder = "{_folder}"
-tags = {_tags}
-"""
+                        [run]
+                        description = "{_description}"
+                        folder = "{_folder}"
+                        tags = {_tags}
+                        """
                 out_f.write(_lines)
             SimvueConfiguration.config_file.cache_clear()
 
@@ -109,7 +109,7 @@ tags = {_tags}
             )
         else:
             _config = simvue.config.user.SimvueConfiguration.fetch()
-
+            
         if use_file and use_file != "pyproject.toml":
             assert _config.config_file() == _config_file
 

--- a/tests/functional/test_run_class.py
+++ b/tests/functional/test_run_class.py
@@ -22,6 +22,7 @@ from simvue.eco.emissions_monitor import TIME_FORMAT, CO2Monitor
 import simvue.run as sv_run
 import simvue.client as sv_cl
 import simvue.sender as sv_send
+import simvue.config.user as sv_cfg
 
 from simvue.api.objects import Run as RunObject
 
@@ -53,8 +54,9 @@ def test_check_run_initialised_decorator() -> None:
 @pytest.mark.online
 def test_run_with_emissions_online(speedy_heartbeat, mock_co2_signal, create_plain_run) -> None:
     run_created, _ = create_plain_run
+    run_created._user_config.eco.co2_signal_api_token = "test_token"
     run_created.config(enable_emission_metrics=True)
-    time.sleep(3)
+    time.sleep(5)
     _run = RunObject(identifier=run_created.id)
     _metric_names = [item[0] for item in _run.metrics]
     client = sv_cl.Client()
@@ -69,19 +71,33 @@ def test_run_with_emissions_online(speedy_heartbeat, mock_co2_signal, create_pla
             output_format="dataframe",
             run_ids=[run_created.id],
         )
-        assert _total_metric_name in _metric_values
-
+        # Check that total = previous total + latest delta
+        _total_values = _metric_values[_total_metric_name].tolist()
+        _delta_values = _metric_values[_delta_metric_name].tolist()
+        assert len(_total_values) > 1
+        for i in range(1, len(_total_values)):
+            assert _total_values[i] == _total_values[i - 1] + _delta_values[i]
 
 @pytest.mark.run
 @pytest.mark.eco
 @pytest.mark.offline
-def test_run_with_emissions_offline(speedy_heartbeat, mock_co2_signal, create_plain_run_offline) -> None:
+def test_run_with_emissions_offline(speedy_heartbeat, mock_co2_signal, create_plain_run_offline, monkeypatch) -> None:
     run_created, _ = create_plain_run_offline
     run_created.config(enable_emission_metrics=True)
-    time.sleep(2)
+    time.sleep(5)
     # Run should continue, but fail to log metrics until sender runs and creates file
     id_mapping = sv_send.sender(os.environ["SIMVUE_OFFLINE_DIRECTORY"])
     _run = RunObject(identifier=id_mapping[run_created.id])
+    _metric_names = [item[0] for item in _run.metrics]
+    for _metric in ["emissions", "energy_consumed"]:
+        _total_metric_name = f"sustainability.{_metric}.total"
+        _delta_metric_name = f"sustainability.{_metric}.delta"
+        assert _total_metric_name not in _metric_names
+        assert _delta_metric_name not in _metric_names
+    # Sender should now have made a local file, and the run should be able to use it to create emissions metrics
+    time.sleep(5)
+    id_mapping = sv_send.sender(os.environ["SIMVUE_OFFLINE_DIRECTORY"])
+    _run.refresh()
     _metric_names = [item[0] for item in _run.metrics]
     client = sv_cl.Client()
     for _metric in ["emissions", "energy_consumed"]:
@@ -95,8 +111,13 @@ def test_run_with_emissions_offline(speedy_heartbeat, mock_co2_signal, create_pl
             output_format="dataframe",
             run_ids=[id_mapping[run_created.id]],
         )
-        assert _total_metric_name in _metric_values
-
+        # Check that total = previous total + latest delta
+        _total_values = _metric_values[_total_metric_name].tolist()
+        _delta_values = _metric_values[_delta_metric_name].tolist()
+        assert len(_total_values) > 1
+        for i in range(1, len(_total_values)):
+            assert _total_values[i] == _total_values[i - 1] + _delta_values[i]
+            
 @pytest.mark.run
 @pytest.mark.parametrize(
     "timestamp",

--- a/tests/functional/test_run_class.py
+++ b/tests/functional/test_run_class.py
@@ -79,6 +79,7 @@ def test_run_with_emissions_offline(speedy_heartbeat, mock_co2_signal, create_pl
     run_created, _ = create_plain_run_offline
     run_created.config(enable_emission_metrics=True)
     time.sleep(2)
+    # Run should continue, but fail to log metrics until sender runs and creates file
     id_mapping = sv_send.sender(os.environ["SIMVUE_OFFLINE_DIRECTORY"])
     _run = RunObject(identifier=id_mapping[run_created.id])
     _metric_names = [item[0] for item in _run.metrics]

--- a/tests/unit/test_ecoclient.py
+++ b/tests/unit/test_ecoclient.py
@@ -2,7 +2,7 @@ import tempfile
 import pytest
 import time
 import pytest_mock
-
+import pytest
 import simvue.eco.api_client as sv_eco_api
 import simvue.eco.emissions_monitor as sv_eco_ems
 
@@ -81,17 +81,15 @@ def test_co2_monitor_properties(mock_co2_signal) -> None:
         assert _ems_monitor.process_data["test_co2_monitor_properties"]
         
         # Will use this equation
-        # Power used = (TDP_cpu * cpu_percent / num_cores) + (TDP_gpu * gpu_percent)
-        assert _ems_monitor.total_power_usage == (80 * 0.2 * 1 / 4) + (130 * 0.4 * 1)
+        # Power used = (TDP_cpu * cpu_percent / num_cores) + (TDP_gpu * gpu_percent) / 1000 (for kW)
+        assert _ems_monitor.total_power_usage == pytest.approx(((80 * 0.2 * 1 / 4) + (130 * 0.4 * 1)) / 1000)
         
-        # Energy used = power used * measure interval
-        assert _ems_monitor.total_energy == _ems_monitor.total_power_usage * 2
+        # Energy used = power used * measure interval / 3600 (for kWh)
+        assert _ems_monitor.total_energy == pytest.approx(_ems_monitor.total_power_usage * 2 / 3600)
         
         # CO2 emission = energy * CO2 intensity
-        # Need to convert CO2 intensity from g/kWh to kg/kWs
-        # So divide by 1000 (g -> kg)
-        # And divide by 60*60 (kWh -> kws)
-        assert _ems_monitor.total_co2_emission == _ems_monitor.total_energy * 40 / (60*60*1000)
+        # Need to convert CO2 intensity from g/kWh to kg/kWh, so divide by 1000
+        assert _ems_monitor.total_co2_emission == pytest.approx(_ems_monitor.total_energy * 40 / 1000)
         
         _ems_monitor.estimate_co2_emissions(**_measure_params)
         # Check delta is half of total, since we've now called this twice

--- a/tests/unit/test_ecoclient.py
+++ b/tests/unit/test_ecoclient.py
@@ -8,7 +8,7 @@ import simvue.eco.emissions_monitor as sv_eco_ems
 
 @pytest.mark.eco
 def test_api_client_get_loc_info(mock_co2_signal) -> None:
-    _client = sv_eco_api.APIClient()
+    _client = sv_eco_api.APIClient(co2_api_token="test_token")
     assert _client.latitude
     assert _client.longitude
     assert _client.country_code
@@ -16,7 +16,7 @@ def test_api_client_get_loc_info(mock_co2_signal) -> None:
 
 @pytest.mark.eco
 def test_api_client_query(mock_co2_signal: dict[str, dict | str]) -> None:
-    _client = sv_eco_api.APIClient()
+    _client = sv_eco_api.APIClient(co2_api_token="test_token")
     _response: sv_eco_api.CO2SignalResponse = _client.get()
     assert _response.carbon_intensity_units == "gCO2e/kWh"
     assert _response.country_code == mock_co2_signal["zone"]
@@ -42,7 +42,7 @@ def test_outdated_data_check(
             local_data_directory=tempd,
             intensity_refresh_interval=1 if refresh else None,
             co2_intensity=None,
-            co2_signal_api_token=None
+            co2_signal_api_token="test_token"
         )   
         _measure_params = {
             "process_id": "test_outdated_data_check",
@@ -65,7 +65,7 @@ def test_co2_monitor_properties(mock_co2_signal) -> None:
             local_data_directory=tempd,
             intensity_refresh_interval=None,
             co2_intensity=40,
-            co2_signal_api_token=None
+            co2_signal_api_token="test_token"
         )   
         _measure_params = {
             "process_id": "test_co2_monitor_properties",

--- a/tests/unit/test_event_alert.py
+++ b/tests/unit/test_event_alert.py
@@ -30,7 +30,7 @@ def test_event_alert_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_event_alert_creation_offline() -> None:
+def test_event_alert_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _alert = EventsAlert.new(
         name=f"events_alert_{_uuid}",
@@ -95,7 +95,7 @@ def test_event_alert_modification_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_event_alert_modification_offline() -> None:
+def test_event_alert_modification_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _alert = EventsAlert.new(
         name=f"events_alert_{_uuid}",

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -33,7 +33,7 @@ def test_events_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_events_creation_offline() -> None:
+def test_events_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _folder_name = f"/simvue_unit_testing/{_uuid}"
     _folder = Folder.new(path=_folder_name, offline=True)

--- a/tests/unit/test_file_artifact.py
+++ b/tests/unit/test_file_artifact.py
@@ -51,13 +51,13 @@ def test_file_artifact_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_file_artifact_creation_offline(offline_test: pathlib.Path, offline_cache_setup) -> None:
+def test_file_artifact_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _folder_name = f"/simvue_unit_testing/{_uuid}"
     _folder = Folder.new(path=_folder_name, offline=True)
     _run = Run.new(name=f"test_file_artifact_creation_offline_{_uuid}",folder=_folder_name, offline=True) 
 
-    _path = offline_test.joinpath("hello_world.txt")
+    _path = pathlib.Path(offline_cache_setup.name).joinpath("hello_world.txt")
 
     with _path.open("w") as out_f:
         out_f.write(f"Hello World! {_uuid}")
@@ -80,7 +80,7 @@ def test_file_artifact_creation_offline(offline_test: pathlib.Path, offline_cach
     assert _local_data.get("name") == f"test_file_artifact_{_uuid}"
     assert _local_data.get("runs") == {_run._identifier: "input"}
     
-    _id_mapping = sender(offline_test.joinpath(".simvue"), 1, 10)
+    _id_mapping = sender(pathlib.Path(offline_cache_setup.name), 1, 10)
     time.sleep(1)
     
     _online_artifact = Artifact(_id_mapping[_artifact.id])

--- a/tests/unit/test_file_artifact.py
+++ b/tests/unit/test_file_artifact.py
@@ -51,7 +51,7 @@ def test_file_artifact_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_file_artifact_creation_offline(offline_test: pathlib.Path) -> None:
+def test_file_artifact_creation_offline(offline_test: pathlib.Path, offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _folder_name = f"/simvue_unit_testing/{_uuid}"
     _folder = Folder.new(path=_folder_name, offline=True)

--- a/tests/unit/test_file_storage.py
+++ b/tests/unit/test_file_storage.py
@@ -23,7 +23,7 @@ def test_create_file_storage_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_create_file_storage_offline() -> None:
+def test_create_file_storage_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _storage = FileStorage.new(name=_uuid, disable_check=True, is_tenant_useable=False, is_default=False, offline=True, is_enabled=False)
     

--- a/tests/unit/test_folder.py
+++ b/tests/unit/test_folder.py
@@ -30,7 +30,7 @@ def test_folder_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_folder_creation_offline() -> None:
+def test_folder_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _path = f"/simvue_unit_testing/objects/folder/{_uuid}"
     _folder = Folder.new(path=_path, offline=True)
@@ -88,7 +88,7 @@ def test_folder_modification_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_folder_modification_offline() -> None:
+def test_folder_modification_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _path = f"/simvue_unit_testing/objects/folder/{_uuid}"
     _description = "Test study"

--- a/tests/unit/test_metric_range_alert.py
+++ b/tests/unit/test_metric_range_alert.py
@@ -34,7 +34,7 @@ def test_metric_range_alert_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_metric_range_alert_creation_offline() -> None:
+def test_metric_range_alert_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _alert = MetricsRangeAlert.new(
         name=f"metrics_range_alert_{_uuid}",
@@ -108,7 +108,7 @@ def test_metric_range_alert_modification_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_metric_range_alert_modification_offline() -> None:
+def test_metric_range_alert_modification_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _alert = MetricsRangeAlert.new(
         name=f"metrics_range_alert_{_uuid}",

--- a/tests/unit/test_metric_threshold_alert.py
+++ b/tests/unit/test_metric_threshold_alert.py
@@ -32,7 +32,7 @@ def test_metric_threshold_alert_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_metric_threshold_alert_creation_offline() -> None:
+def test_metric_threshold_alert_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _alert = MetricsThresholdAlert.new(
         name=f"metrics_threshold_alert_{_uuid}",
@@ -107,7 +107,7 @@ def test_metric_threshold_alert_modification_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_metric_threshold_alert_modification_offline() -> None:
+def test_metric_threshold_alert_modification_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _alert = MetricsThresholdAlert.new(
         name=f"metrics_threshold_alert_{_uuid}",

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -50,7 +50,7 @@ def test_metrics_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_metrics_creation_offline() -> None:
+def test_metrics_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _folder_name = f"/simvue_unit_testing/{_uuid}"
     _folder = Folder.new(path=_folder_name, offline=True)

--- a/tests/unit/test_object_artifact.py
+++ b/tests/unit/test_object_artifact.py
@@ -38,7 +38,7 @@ def test_object_artifact_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_object_artifact_creation_offline(offline_test: pathlib.Path) -> None:
+def test_object_artifact_creation_offline(offline_test: pathlib.Path, offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _folder_name = f"/simvue_unit_testing/{_uuid}"
     _folder = Folder.new(path=_folder_name, offline=True)

--- a/tests/unit/test_object_artifact.py
+++ b/tests/unit/test_object_artifact.py
@@ -38,7 +38,7 @@ def test_object_artifact_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_object_artifact_creation_offline(offline_test: pathlib.Path, offline_cache_setup) -> None:
+def test_object_artifact_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _folder_name = f"/simvue_unit_testing/{_uuid}"
     _folder = Folder.new(path=_folder_name, offline=True)
@@ -63,7 +63,7 @@ def test_object_artifact_creation_offline(offline_test: pathlib.Path, offline_ca
     assert _local_data.get("mime_type") == "application/vnd.simvue.numpy.v1"
     assert _local_data.get("runs") == {_run.id: "input"}
         
-    _id_mapping = sender(offline_test.joinpath(".simvue"), 1, 10)
+    _id_mapping = sender(pathlib.Path(offline_cache_setup.name), 1, 10)
     time.sleep(1)
     
     _online_artifact = Artifact(_id_mapping.get(_artifact.id))

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -24,7 +24,7 @@ def test_run_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_run_creation_offline() -> None:
+def test_run_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _run_name = f"simvue_offline_run_{_uuid}"
     _folder_name = f"/simvue_unit_testing/{_uuid}"
@@ -91,7 +91,7 @@ def test_run_modification_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_run_modification_offline() -> None:
+def test_run_modification_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _run_name = f"simvue_offline_run_{_uuid}"
     _folder_name = f"/simvue_unit_testing/{_uuid}"

--- a/tests/unit/test_s3_storage.py
+++ b/tests/unit/test_s3_storage.py
@@ -44,7 +44,7 @@ def test_create_s3_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_create_s3_offline() -> None:
+def test_create_s3_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _storage = S3Storage.new(
         name=_uuid,

--- a/tests/unit/test_tag.py
+++ b/tests/unit/test_tag.py
@@ -21,7 +21,7 @@ def test_tag_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_tag_creation_offline() -> None:
+def test_tag_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _tag = Tag.new(name=f"test_tag_{_uuid}", offline=True)
     _tag.commit()
@@ -68,7 +68,7 @@ def test_tag_modification_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_tag_modification_offline() -> None:
+def test_tag_modification_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _tag = Tag.new(name=f"test_tag_{_uuid}", offline=True)
     _tag.commit()

--- a/tests/unit/test_tenant.py
+++ b/tests/unit/test_tenant.py
@@ -26,7 +26,7 @@ def test_create_tenant_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_create_tenant_offline() -> None:
+def test_create_tenant_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _tenant = Tenant.new(name=_uuid, offline=True)
     _tenant.commit()

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -38,7 +38,7 @@ def test_create_user_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_create_user_offline() -> None:
+def test_create_user_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _user = User.new(
         username="jbloggs",

--- a/tests/unit/test_user_alert.py
+++ b/tests/unit/test_user_alert.py
@@ -26,7 +26,7 @@ def test_user_alert_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_user_alert_creation_offline() -> None:
+def test_user_alert_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _alert = UserAlert.new(
         name=f"users_alert_{_uuid}",
@@ -84,7 +84,7 @@ def test_user_alert_modification_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_user_alert_modification_offline() -> None:
+def test_user_alert_modification_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _alert = UserAlert.new(
         name=f"users_alert_{_uuid}",
@@ -176,7 +176,7 @@ def test_user_alert_status() -> None:
     
 @pytest.mark.api
 @pytest.mark.offline
-def test_user_alert_status_offline() -> None:
+def test_user_alert_status_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _alert = UserAlert.new(
         name=f"users_alert_{_uuid}",


### PR DESCRIPTION
# EcoClient units are inconsistent and bugfixes

**Python Version(s) Tested:** 3.10
**Operating System(s):** Ubuntu

## 📝 Summary
There were some inconsistencies in the units used by the ecoclient equations - have now changed this to consistently use kWh for energy, and kg for CO2 emissions

This actually now fixes a whole load of bugs, so many ive lost track of what's what...
