### PR TITLE
Fix Visibility settings

### DIFF
--- a/simvue/client.py
+++ b/simvue/client.py
@@ -181,7 +181,7 @@ class Client:
         output_format: typing.Literal["dict", "objects", "dataframe"] = "objects",
         count_limit: pydantic.PositiveInt | None = 100,
         start_index: pydantic.NonNegativeInt = 0,
-        show_shared: bool = False,
+        show_shared: bool = True,
         sort_by_columns: list[tuple[str, bool]] | None = None,
     ) -> DataFrame | typing.Generator[tuple[str, Run], None, None] | None:
         """Retrieve all runs matching filters.
@@ -210,7 +210,7 @@ class Client:
         start_index : int, optional
             the index from which to count entries. Default is 0.
         show_shared : bool, optional
-            whether to include runs shared with the current user. Default is False.
+            whether to include runs shared with the current user. Default is True.
         sort_by_columns : list[tuple[str, bool]], optional
             sort by columns in the order given,
             list of tuples in the form (column_name: str, sort_descending: bool),

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -234,8 +234,9 @@ class Client:
         RuntimeError
             if there was a failure in data retrieval from the server
         """
+        filters = filters or []
         if not show_shared:
-            filters = (filters or []) + ["user == self"]
+            filters += ["user == self"]
 
         _runs = Run.get(
             count=count_limit,

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -729,11 +729,11 @@ class Run:
         if name:
             self._sv_obj.name = name
 
-        self._sv_obj.visibility = {
-            "users": visibility if isinstance(visibility, list) else [],
-            "tenant": visibility == "tenant",
-            "public": visibility == "public",
-        }
+        self._sv_obj.visibility.tenant = visibility == "tenant"
+        self._sv_obj.visibility.public = visibility == "public"
+        self._sv_obj.visibility.users = (
+            visibility if isinstance(visibility, list) else []
+        )
         self._sv_obj.ttl = self._retention
         self._sv_obj.status = self._status
         self._sv_obj.tags = tags

--- a/tests/functional/test_client.py
+++ b/tests/functional/test_client.py
@@ -227,7 +227,7 @@ def test_get_artifacts_as_files(
 def test_get_runs(create_test_run: tuple[sv_run.Run, dict], output_format: str, sorting: list[tuple[str, bool]] | None) -> None:
     client = svc.Client()
 
-    _result = client.get_runs(filters=None, output_format=output_format, count_limit=10, sort_by_columns=sorting)
+    _result = client.get_runs(filters=[], output_format=output_format, count_limit=10, sort_by_columns=sorting)
 
     if output_format == "dataframe":
         assert not _result.empty

--- a/tests/functional/test_run_class.py
+++ b/tests/functional/test_run_class.py
@@ -104,7 +104,7 @@ def test_run_with_emissions_offline(speedy_heartbeat, mock_co2_signal, create_pl
 )
 @pytest.mark.parametrize("overload_buffer", (True, False), ids=("overload", "normal"))
 @pytest.mark.parametrize(
-    "visibility", ("bad_option", "tenant", "public", ["ciuser01"], None)
+    "visibility", ("bad_option", "tenant", "public", ["user01"], None)
 )
 def test_log_metrics(
     overload_buffer: bool,
@@ -219,9 +219,9 @@ def test_log_metrics_offline(create_plain_run_offline: tuple[sv_run.Run, dict]) 
 
 @pytest.mark.run
 @pytest.mark.parametrize(
-    "visibility", ("bad_option", "tenant", "public", ["ciuser01"], None)
+    "visibility", ("bad_option", "tenant", "public", ["user01"], None)
 )
-def test_visibility(
+def test_visibility_online(
     request: pytest.FixtureRequest,
     visibility: typing.Literal["public", "tenant"] | list[str] | None,
 ) -> None:
@@ -270,7 +270,7 @@ def test_visibility(
 @pytest.mark.run
 @pytest.mark.offline
 @pytest.mark.parametrize(
-    "visibility", ("bad_option", "tenant", "public", ["ciuser01"], None)
+    "visibility", ("bad_option", "tenant", "public", ["user01"], None)
 )
 def test_visibility_offline(
     request: pytest.FixtureRequest,

--- a/tests/functional/test_run_class.py
+++ b/tests/functional/test_run_class.py
@@ -217,6 +217,109 @@ def test_log_metrics_offline(create_plain_run_offline: tuple[sv_run.Run, dict]) 
     _steps = set(_steps)
     assert len(_steps) == 1
 
+@pytest.mark.run
+@pytest.mark.parametrize(
+    "visibility", ("bad_option", "tenant", "public", ["ciuser01"], None)
+)
+def test_visibility(
+    request: pytest.FixtureRequest,
+    visibility: typing.Literal["public", "tenant"] | list[str] | None,
+) -> None:
+
+    run = sv_run.Run()
+    run.config(suppress_errors=False)
+
+    if visibility == "bad_option":
+        with pytest.raises(SimvueRunError, match="visibility") as e:
+            run.init(
+                name=f"test_visibility_{str(uuid.uuid4()).split('-', 1)[0]}",
+                tags=[
+                    "simvue_client_unit_tests",
+                    request.node.name.replace("[", "_").replace("]", "_"),
+                ],
+                folder="/simvue_unit_testing",
+                retention_period="1 hour",
+                visibility=visibility,
+            )
+        return
+
+    run.init(
+        name=f"test_visibility_{str(uuid.uuid4()).split('-', 1)[0]}",
+        tags=[
+            "simvue_client_unit_tests",
+            request.node.name.replace("[", "_").replace("]", "_"),
+        ],
+        folder="/simvue_unit_testing",
+        visibility=visibility,
+        retention_period="1 hour",
+    )
+    time.sleep(1)
+    _id = run._id
+    run.close()
+    _retrieved_run = RunObject(identifier=_id)
+
+    if visibility == "tenant":
+        assert _retrieved_run.visibility.tenant
+    elif visibility == "public":
+        assert _retrieved_run.visibility.public
+    elif not visibility:
+        assert not _retrieved_run.visibility.tenant and not _retrieved_run.visibility.public
+    else:
+        assert _retrieved_run.visibility.users == visibility
+    
+@pytest.mark.run
+@pytest.mark.offline
+@pytest.mark.parametrize(
+    "visibility", ("bad_option", "tenant", "public", ["ciuser01"], None)
+)
+def test_visibility_offline(
+    request: pytest.FixtureRequest,
+    monkeypatch,
+    visibility: typing.Literal["public", "tenant"] | list[str] | None,
+) -> None:
+    with tempfile.TemporaryDirectory() as tempd:
+        os.environ["SIMVUE_OFFLINE_DIRECTORY"] = tempd
+        run = sv_run.Run(mode="offline")
+        run.config(suppress_errors=False)
+
+        if visibility == "bad_option":
+            with pytest.raises(SimvueRunError, match="visibility") as e:
+                run.init(
+                    name=f"test_visibility_{str(uuid.uuid4()).split('-', 1)[0]}",
+                    tags=[
+                        "simvue_client_unit_tests",
+                        request.node.name.replace("[", "_").replace("]", "_"),
+                    ],
+                    folder="/simvue_unit_testing",
+                    retention_period="1 hour",
+                    visibility=visibility,
+                )
+            return
+
+        run.init(
+            name=f"test_visibility_{str(uuid.uuid4()).split('-', 1)[0]}",
+            tags=[
+                "simvue_client_unit_tests",
+                request.node.name.replace("[", "_").replace("]", "_"),
+            ],
+            folder="/simvue_unit_testing",
+            visibility=visibility,
+            retention_period="1 hour",
+        )
+        time.sleep(1)
+        _id = run._id
+        _id_mapping = sv_send.sender(os.environ["SIMVUE_OFFLINE_DIRECTORY"], 2, 10)
+        run.close()
+        _retrieved_run = RunObject(identifier=_id_mapping.get(_id))
+
+        if visibility == "tenant":
+            assert _retrieved_run.visibility.tenant
+        elif visibility == "public":
+            assert _retrieved_run.visibility.public
+        elif not visibility:
+            assert not _retrieved_run.visibility.tenant and not _retrieved_run.visibility.public
+        else:
+            assert _retrieved_run.visibility.users == visibility
 
 @pytest.mark.run
 def test_log_events_online(create_test_run: tuple[sv_run.Run, dict]) -> None:


### PR DESCRIPTION
# Fix Visibility settings

**Issue:** #777, #779

**Python Version(s) Tested:** 3.10

**Operating System(s):** Ubuntu

## 📝 Summary
Visibility settings in `run.init` weren't applying correctly due to it not using the Visibility class

## 🔍 Diagnosis

James spotted this while doing FDS sims for Interflam

## 🔄 Changes

Just changed visibility to change using the Visibility class instead of a dict update. Also fix `show_shared` to default to True in `client.get_runs`). Added new visibility tests

Setting user visibilities test is failing, but this is expected as it is a server side bug

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [ ] Pre-commit hooks passing.
- [ ] Quality checks passing.
