### PR TITLE
🐛 Add missing user property to API Run object

### DIFF
--- a/simvue/api/objects/run.py
+++ b/simvue/api/objects/run.py
@@ -230,6 +230,11 @@ class Run(SimvueObject):
         self._staging["metadata"] = metadata
 
     @property
+    def user(self) -> str:
+        """Return the user associate with this run."""
+        return self._get_attribute("user")
+
+    @property
     @staging_check
     def description(self) -> str:
         """Set/retrieve the description for this run.


### PR DESCRIPTION
# Add missing user property to API Run object

**Issue:** https://github.com/simvue-io/python-api/issues/793

**Python Version(s) Tested:** Python versions this fix has been verified against.

**Operating System(s):** Operating systems this fix has been tested in.

## 📝 Summary

Adds the 'user' attribute to the Run API low level object

## 🔍 Diagnosis
`Run.user` property was missing, this is needed by the CLI.

## 🔄 Changes

Added missing `@property'

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [ ] Pre-commit hooks passing.
- [ ] Quality checks passing.
