### PR TITLE
Need to set system details in reconnect()

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -983,6 +983,7 @@ class Run:
 
         self._id = run_id
         self._sv_obj = RunObject(identifier=self._id, _read_only=False)
+        self._sv_obj.system = get_system()
         self._start()
 
         return True


### PR DESCRIPTION
This is a simple bug fix which ensures that `system` is populated when `reconnect()` is used. Currently such runs end up with `system` being completely empty.