### PR TITLE
Fix Duplication of Entries in Pagination

### DIFF
--- a/simvue/api/request.py
+++ b/simvue/api/request.py
@@ -303,12 +303,18 @@ def get_paginated(
         server response
     """
     _offset: int = offset or 0
+
+    # Restrict the number of entries retrieved to be paginated,
+    # if the count requested is below page limit use this value
+    # else if undefined or greater than the page limit use the limit
+    _request_count: int = min(count or MAX_ENTRIES_PER_PAGE, MAX_ENTRIES_PER_PAGE)
+
     while (
         _response := get(
             url=url,
             headers=headers,
             params=(params or {})
-            | {"count": count or MAX_ENTRIES_PER_PAGE, "start": _offset},
+            | {"count": _request_count, "start": _offset},
             timeout=timeout,
             json=json,
         )

--- a/simvue/api/request.py
+++ b/simvue/api/request.py
@@ -313,8 +313,7 @@ def get_paginated(
         _response := get(
             url=url,
             headers=headers,
-            params=(params or {})
-            | {"count": _request_count, "start": _offset},
+            params=(params or {}) | {"count": _request_count, "start": _offset},
             timeout=timeout,
             json=json,
         )


### PR DESCRIPTION
Addresses a bug whereby if the count requested was greater than the pagination limit, rather than using the limit the user count was still passed meaning duplication of entries
