### PR TITLE
Kzscisoft/781 uploads silently fail resulting in 0b files

### DIFF
--- a/simvue/api/objects/alert/fetch.py
+++ b/simvue/api/objects/alert/fetch.py
@@ -150,4 +150,6 @@ class Alert:
                     ),
                 )
             else:
-                raise RuntimeError(f"Unrecognised alert source '{_entry['source']}'")
+                raise RuntimeError(
+                    f"Unrecognised alert source '{_entry['source']}' with data '{_entry}'"
+                )

--- a/simvue/api/objects/artifact/file.py
+++ b/simvue/api/objects/artifact/file.py
@@ -37,6 +37,7 @@ class FileArtifact(ArtifactBase):
         file_path: pydantic.FilePath,
         mime_type: str | None,
         metadata: dict[str, typing.Any] | None,
+        upload_timeout: int | None = None,
         offline: bool = False,
         **kwargs,
     ) -> Self:
@@ -56,6 +57,8 @@ class FileArtifact(ArtifactBase):
             the mime type for this file, else this is determined
         metadata : dict[str, Any] | None
             supply metadata information for this artifact
+        upload_timeout : int | None, optional
+            specify the timeout in seconds for upload
         offline : bool, optional
             whether to define this artifact locally, default is False
 
@@ -100,6 +103,6 @@ class FileArtifact(ArtifactBase):
             return _artifact
 
         with open(_file_orig_path, "rb") as out_f:
-            _artifact._upload(file=out_f)
+            _artifact._upload(file=out_f, timeout=upload_timeout, file_size=_file_size)
 
         return _artifact

--- a/simvue/api/objects/artifact/object.py
+++ b/simvue/api/objects/artifact/object.py
@@ -39,6 +39,7 @@ class ObjectArtifact(ArtifactBase):
         storage: str | None,
         obj: typing.Any,
         metadata: dict[str, typing.Any] | None,
+        upload_timeout: int | None = None,
         allow_pickling: bool = True,
         offline: bool = False,
         **kwargs,
@@ -57,6 +58,8 @@ class ObjectArtifact(ArtifactBase):
             object to serialize and upload
         metadata : dict[str, Any] | None
             supply metadata information for this artifact
+        upload_timeout : int | None, optional
+            specify the timeout in seconds for upload
         allow_pickling : bool, optional
             whether to allow the object to be pickled if no other
             serialization found. Default is True
@@ -119,5 +122,11 @@ class ObjectArtifact(ArtifactBase):
         if offline:
             return _artifact
 
-        _artifact._upload(file=io.BytesIO(_serialized))
+        _file_data = io.BytesIO(_serialized)
+
+        _artifact._upload(
+            file=_file_data,
+            timeout=upload_timeout,
+            file_size=len(_file_data.getbuffer()),
+        )
         return _artifact

--- a/simvue/api/request.py
+++ b/simvue/api/request.py
@@ -68,6 +68,7 @@ def post(
     params: dict[str, str],
     data: typing.Any,
     is_json: bool = True,
+    timeout: int | None = None,
     files: dict[str, typing.Any] | None = None,
 ) -> requests.Response:
     """HTTP POST with retries

--- a/simvue/api/request.py
+++ b/simvue/api/request.py
@@ -103,7 +103,7 @@ def post(
         headers=headers,
         params=params,
         data=data_sent,
-        timeout=DEFAULT_API_TIMEOUT,
+        timeout=timeout,
         files=files,
     )
 

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -70,7 +70,6 @@ except ImportError:
 if typing.TYPE_CHECKING:
     from .factory.dispatch import DispatcherBaseClass
 
-UPLOAD_TIMEOUT: int = 30
 HEARTBEAT_INTERVAL: int = 60
 RESOURCES_METRIC_PREFIX: str = "resources"
 


### PR DESCRIPTION
# Fix 0B Uploads

**Issue:** https://github.com/simvue-io/python-api/issues/781

**Python Version(s) Tested:** 3.13
**Operating System(s):** Ubuntu 25.04

## 📝 Summary

Uploading files above a certain size led to 0B files being available to download.

## 🔍 Diagnosis

For some reason this is related to `requests.post` timeout even though I was led to believe this is the timeout for hearing from the server, not for request duration.

## 🔄 Changes

Add dynamic timeout which increases based on file size.

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [ ] Pre-commit hooks passing.
- [ ] Quality checks passing.
