### PR TITLE
Don't commit artifact in sender

### DIFF
--- a/simvue/sender.py
+++ b/simvue/sender.py
@@ -15,6 +15,7 @@ import psutil
 from simvue.config.user import SimvueConfiguration
 
 import simvue.api.objects
+from simvue.api.objects.artifact.base import ArtifactBase
 from simvue.eco.emissions_monitor import CO2Monitor
 from simvue.version import __version__
 
@@ -81,7 +82,8 @@ def upload_cached_file(
         obj_for_upload.on_reconnect(id_mapping)
 
     try:
-        obj_for_upload.commit()
+        if not issubclass(_instance_class, ArtifactBase):
+            obj_for_upload.commit()
         _new_id = obj_for_upload.id
     except RuntimeError as error:
         if "status 409" in error.args[0]:


### PR DESCRIPTION
# Fix 'cannot commit artifact' error message in sender

**Python Version(s) Tested:** 3.10

**Operating System(s):** Ubuntu

## 📝 Summary

Sender automatically does `.commit` on any objects read from the cache. This isnt required for artifacts, hence you get this error:

```
INFO:simvue.FileArtifact:Cannot call method 'commit' on write-once type 'Artifact'
```

## 🔄 Changes

Simply add a check into the sender so that commit isnt called if the object class is a subclass of `ArtifactBase`

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [ ] Pre-commit hooks passing.
- [ ] Quality checks passing.
