### PR TITLE
🚸  Improve checks for offline cache directory specification

### DIFF
--- a/.github/workflows/test_client_windows_nightlies.yml
+++ b/.github/workflows/test_client_windows_nightlies.yml
@@ -61,7 +61,7 @@ jobs:
         SIMVUE_TOKEN: ${{ secrets.SIMVUE_TOKEN }}
       run: >-
         python -m pytest -x
-        -m object_removal -m 'not unix' -c /dev/null -p no:warnings
+        -m 'object_removal and not unix' -c /dev/null -p no:warnings
         -n 0 -v -o cache_dir=${GITHUB_WORKSPACE}/.pytest-cache
   dispatch_tests:
     runs-on: windows-latest
@@ -85,7 +85,7 @@ jobs:
         SIMVUE_TOKEN: ${{ secrets.SIMVUE_TOKEN }}
       run: >-
         python -m pytest -x
-        -m dispatch -m 'not unix' -c /dev/null -p no:warnings
+        -m 'dispatch and not unix' -c /dev/null -p no:warnings
         -n 0 -v -o cache_dir=${GITHUB_WORKSPACE}/.pytest-cache
   run_tests_online:
     runs-on: windows-latest
@@ -110,7 +110,7 @@ jobs:
         SIMVUE_TOKEN: ${{ secrets.SIMVUE_TOKEN }}
       run: >-
         python -m pytest -x
-        -m run -m online -m 'not unix' -c /dev/null -p no:warnings
+        -m run -m 'online and not unix' -c /dev/null -p no:warnings
         -n 0 -v -o cache_dir=${GITHUB_WORKSPACE}/.pytest-cache
   run_tests_offline:
     runs-on: windows-latest
@@ -135,7 +135,7 @@ jobs:
         SIMVUE_TOKEN: ${{ secrets.SIMVUE_TOKEN }}
       run: >-
         python -m pytest -x
-        -m run -m offline -m 'not unix' -c /dev/null -p no:warnings
+        -m run -m 'offline and not unix' -c /dev/null -p no:warnings
         -n 0 -v -o cache_dir=${GITHUB_WORKSPACE}/.pytest-cache
   config_tests:
     runs-on: windows-latest
@@ -159,7 +159,7 @@ jobs:
         SIMVUE_TOKEN: ${{ secrets.SIMVUE_TOKEN }}
       run: >-
         python -m pytest -x
-        -m config -m 'not unix' -c /dev/null -p no:warnings
+        -m 'config and not unix' -c /dev/null -p no:warnings
         -n 0 -v -o cache_dir=${GITHUB_WORKSPACE}/.pytest-cache
   executor_tests:
     runs-on: windows-latest
@@ -183,7 +183,7 @@ jobs:
         SIMVUE_TOKEN: ${{ secrets.SIMVUE_TOKEN }}
       run: >-
         python -m pytest -x
-        -m executor -n 'not unix' -c /dev/null -p no:warnings
+        -m 'executor and not unix' -c /dev/null -p no:warnings
         -n 0 -v -o cache_dir=${GITHUB_WORKSPACE}/.pytest-cache
   api_tests:
     runs-on: windows-latest
@@ -207,7 +207,7 @@ jobs:
         SIMVUE_TOKEN: ${{ secrets.SIMVUE_TOKEN }}
       run: >-
         python -m pytest -x
-        -m api -m 'not unix' -c /dev/null -p no:warnings
+        -m 'api and not unix' -c /dev/null -p no:warnings
         -n 0 -v -o cache_dir=${GITHUB_WORKSPACE}/.pytest-cache
   local_tests:
     runs-on: windows-latest
@@ -231,5 +231,5 @@ jobs:
         SIMVUE_TOKEN: ${{ secrets.SIMVUE_TOKEN }}
       run: >-
         python -m pytest -x
-        -m local -m 'not unix' -c /dev/null -p no:warnings
+        -m 'local and not unix' -c /dev/null -p no:warnings
         -n 0 -v -o cache_dir=${GITHUB_WORKSPACE}/.pytest-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improves handling of Conda based environments in metadata collection.
 - Adds additional options to `Client.get_runs`.
 - Added ability to include environment variables within metadata for runs.
+- Improves checks on `offline.cache` directory specification in config file.
 
 ## [v2.1.2](https://github.com/simvue-io/client/releases/tag/v2.1.2) - 2025-06-25
 

--- a/simvue/config/parameters.py
+++ b/simvue/config/parameters.py
@@ -7,7 +7,7 @@ Pydantic models for elements of the Simvue configuration file
 """
 
 import logging
-import re
+import os
 import time
 import pydantic
 import typing
@@ -53,10 +53,12 @@ class OfflineSpecifications(pydantic.BaseModel):
     @pydantic.field_validator("cache")
     @classmethod
     def check_valid_cache_path(cls, cache: pathlib.Path) -> pathlib.Path:
-        if not re.fullmatch(
-            r"^(\/|([a-zA-Z]:\\))?([\w\s.-]+[\\/])*[\w\s.-]*$", f"{cache}"
-        ):
-            raise AssertionError(f"Value '{cache}' is not a valid cache path.")
+        if not cache.parent.exists():
+            raise FileNotFoundError(f"No such directory '{cache.parent}'.")
+        if not cache.parent.is_dir():
+            raise FileNotFoundError(f"'{cache.parent}' is not a directory.")
+        if not os.access(cache.parent, os.W_OK):
+            raise AssertionError(f"'{cache.parent}' is not a writable location.")
         return cache
 
 


### PR DESCRIPTION
# Fix failing cache directory

**Issue:** https://github.com/simvue-io/python-api/issues/848

**Python Version(s) Tested:** 3.13

**Operating System(s):** Ubuntu 25.04

## 📝 Summary

`offline.cache` key fails validation on Windows systems due to constraints.

## 🔍 Diagnosis

Windows CI fails due to `~` in path.

## 🔄 Changes
Checks were updated to:
- Confirm location's parent directory exists.
- Confirm the parent directory is writable.

## ✔️ Checklist
- [x] Unit and integration tests passing.
- [x] Pre-commit hooks passing.
- [x] Quality checks passing.
