### PR TITLE
Fixes offline mode for multi dimensional metrics

### DIFF
--- a/simvue/api/objects/grids.py
+++ b/simvue/api/objects/grids.py
@@ -79,11 +79,14 @@ class Grid(SimvueObject):
         id_mapping : dict[str, str]
             mapping from offline identifier to new online identifier.
         """
-        for run_id, metric_name in self._staging.pop("runs", []):
+        _online_runs = [
+            (id_mapping[run_id], metric_name)
+            for run_id, metric_name in self._staging.pop("runs", [])
+        ]
+        super().commit()  # TODO this means the sender iwll commit twice - that ok?
+        for run_id, metric_name in _online_runs:
             try:
-                self.attach_metric_for_run(
-                    run_id=id_mapping[run_id], metric_name=metric_name
-                )
+                self.attach_metric_for_run(run_id=run_id, metric_name=metric_name)
             except KeyError:
                 raise RuntimeError("Failed to retrieve online run identifier.")
 
@@ -146,6 +149,7 @@ class Grid(SimvueObject):
             name=name,
             _read_only=False,
             _offline=offline,
+            **kwargs,
         )
 
     @property

--- a/simvue/api/objects/grids.py
+++ b/simvue/api/objects/grids.py
@@ -79,11 +79,11 @@ class Grid(SimvueObject):
         id_mapping : dict[str, str]
             mapping from offline identifier to new online identifier.
         """
-        _online_runs = [
+        _online_runs = (
             (id_mapping[run_id], metric_name)
             for run_id, metric_name in self._staging.pop("runs", [])
-        ]
-        super().commit()  # TODO this means the sender iwll commit twice - that ok?
+        )
+        super().commit()
         for run_id, metric_name in _online_runs:
             try:
                 self.attach_metric_for_run(run_id=run_id, metric_name=metric_name)

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -1460,7 +1460,10 @@ class Run:
             return False
 
         try:
-            _grid_attach = Grid(identifier=self._grids[grid_name]["id"])
+            _grid_attach = Grid(
+                identifier=self._grids[grid_name]["id"],
+                offline=self._user_config.run.mode == "offline",
+            )
             _grid_attach.read_only(False)
             _grid_attach.attach_metric_for_run(self.id, metric_name)
             self._grids[metric_name] = self._grids[grid_name]

--- a/tests/functional/test_run_class.py
+++ b/tests/functional/test_run_class.py
@@ -301,13 +301,12 @@ def test_log_metrics_offline(
     sv_send.sender(os.environ["SIMVUE_OFFLINE_DIRECTORY"], 2, 10)
     attempts: int = 0
 
-    while not (_data := client.get_metric_values(
+    _data = client.get_metric_values(
         run_ids=[client.get_run_id_from_name(run_name)],
         metric_names=list(METRICS.keys()),
         xaxis="step",
         aggregate=False,
-    )) and attempts < 5:
-        sv_send.sender(os.environ["SIMVUE_OFFLINE_DIRECTORY"], 2, 10)
+    )
 
     assert sorted(set(METRICS.keys())) == sorted(set(_data.keys()))
     _steps = []

--- a/tests/functional/test_run_class.py
+++ b/tests/functional/test_run_class.py
@@ -236,8 +236,25 @@ def test_log_metrics_online(
     run.close()
 
     #TODO: No client functions defined for grids yet
-    if metric_type != "tensor":
-
+    # Temporary solution - use direct API endpoints
+    if metric_type == "tensor":
+        for name, values in METRICS.items():
+            if overload_buffer:
+                for i in range(run._dispatcher._max_buffer_size * 3):
+                    response = requests.get(
+                        url=f"{run._user_config.server.url}/runs/{run.id}/metrics/{name}/values?step={i}",
+                        headers=run._sv_obj._headers,
+                    )
+                    assert response.status_code == 200            
+                    numpy.testing.assert_almost_equal(numpy.array(response.json().get("array")), i * numpy.identity(10))
+            else:
+                response = requests.get(
+                    url=f"{run._user_config.server.url}/runs/{run.id}/metrics/{name}/values?step=0",
+                    headers=run._sv_obj._headers,
+                )
+                assert response.status_code == 200            
+                numpy.testing.assert_almost_equal(numpy.array(response.json().get("array")), values)
+    else:    
         time.sleep(2.0 if overload_buffer else 1.0)
         client = sv_cl.Client()
         _data = client.get_metric_values(
@@ -282,7 +299,6 @@ def test_log_metrics_offline(
     create_plain_run_offline: tuple[sv_run.Run, dict],
     metric_type: typing.Literal["regular", "tensor"]
 ) -> None:
-    METRICS = {"a": 10, "b": 1.2, "c": 2}
     run, _ = create_plain_run_offline
     run_name = run.name
     if metric_type == "tensor":
@@ -296,24 +312,43 @@ def test_log_metrics_offline(
             ]),
             axes_labels=["x", "y"]
         )
+    else:
+        METRICS = {"a": 10, "b": 1.2, "c": 2}
+        
     run.log_metrics(METRICS)
-    client = sv_cl.Client()
-    sv_send.sender(os.environ["SIMVUE_OFFLINE_DIRECTORY"], 2, 10)
-    attempts: int = 0
+    
+    time.sleep(1)
+    id_mapping = sv_send.sender(os.environ["SIMVUE_OFFLINE_DIRECTORY"], 2, 10)
+    time.sleep(1)
+    
+    if metric_type == "tensor":
+        for name, values in METRICS.items():
+            response = requests.get(
+                url=f"{run._user_config.server.url}/runs/{id_mapping[run.id]}/metrics/{name}/values?step=0",
+                headers={
+                    "Authorization": f"Bearer {run._user_config.server.token.get_secret_value()}",
+                    "User-Agent": "Simvue Python client",
+                    "Accept-Encoding": "gzip",
+                }
+            )
+            assert response.status_code == 200
+            numpy.testing.assert_almost_equal(numpy.array(response.json().get("array")), values)
+    else:
+        client = sv_cl.Client()
 
-    _data = client.get_metric_values(
-        run_ids=[client.get_run_id_from_name(run_name)],
-        metric_names=list(METRICS.keys()),
-        xaxis="step",
-        aggregate=False,
-    )
+        _data = client.get_metric_values(
+            run_ids=[client.get_run_id_from_name(run_name)],
+            metric_names=list(METRICS.keys()),
+            xaxis="step",
+            aggregate=False,
+        )
 
-    assert sorted(set(METRICS.keys())) == sorted(set(_data.keys()))
-    _steps = []
-    for entry in _data.values():
-        _steps += [i[0] for i in entry.keys()]
-    _steps = set(_steps)
-    assert len(_steps) == 1
+        assert sorted(set(METRICS.keys())) == sorted(set(_data.keys()))
+        _steps = []
+        for entry in _data.values():
+            _steps += [i[0] for i in entry.keys()]
+        _steps = set(_steps)
+        assert len(_steps) == 1
 
 @pytest.mark.run
 @pytest.mark.parametrize(

--- a/tests/unit/test_grids.py
+++ b/tests/unit/test_grids.py
@@ -72,7 +72,7 @@ def test_grid_creation_offline() -> None:
     with _grid._local_staging_file.open() as in_f:
         _local_data = json.load(in_f)
 
-    assert _local_data.get("runs", [None])[0] == _run.id
+    assert _local_data.get("runs", [None])[0] == [_run.id, "A"]
     npt.assert_array_equal(numpy.array(_local_data.get("grid")), _grid_def)
     _id_mapping = sender(_grid._local_staging_file.parents[1], 1, 10, ["folders", "runs", "grids"])
     time.sleep(1)


### PR DESCRIPTION
# Offline Mode Fix

**Python Version(s) Tested:** 3.10

**Operating System(s):** Ubuntu

## 📝 Summary

Fixes bug where offline mode wasnt working with multidimensional metrics. This was caused by it trying to attach a grid to a run within `on_reconnect`, which happens before the grid is actually created, meaning the joining to a run was failing. Have fixed this so that it does a commit within `on_reconnect` first. This does mean that the code will do `.commit()` on the grid object twice, once within `on_reconnect` and once within `sender`, but I couldn't think of a better alternative and dont think itll cause any harm?

Also fixed and improved tests for multidimensional metrics, using direct requests to the API endpoint to get the values back while the Client methods are unimplemented


## ✔️ Checklist
- [x] Unit and integration tests passing.
- [x] Pre-commit hooks passing.
- [x] Quality checks passing.
