### PR TITLE
Wk9874/863 metric name validation

### DIFF
--- a/simvue/models.py
+++ b/simvue/models.py
@@ -5,8 +5,8 @@ import pydantic
 
 
 FOLDER_REGEX: str = r"^/.*"
-NAME_REGEX: str = r"^[a-zA-Z0-9\-\_\s\/\.:]+$"
-METRIC_KEY_REGEX: str = r"^[a-zA-Z0-9\-\_\s\/\.:=><]+$"
+NAME_REGEX: str = r"^[a-zA-Z0-9\-\_\s\/\.:=><]+$"
+METRIC_KEY_REGEX: str = r"^[a-zA-Z0-9\-\_\s\/\.:=><+\(\)]+$"
 DATETIME_FORMAT: str = "%Y-%m-%dT%H:%M:%S.%f"
 
 MetadataKeyString = typing.Annotated[

--- a/tests/functional/test_run_class.py
+++ b/tests/functional/test_run_class.py
@@ -167,7 +167,7 @@ def test_log_metrics_online(
     visibility: typing.Literal["public", "tenant"] | list[str] | None,
     metric_type: typing.Literal["regular", "tensor"],
 ) -> None:
-    METRICS = {"a": 10, "b": 1.2}
+    METRICS = {"a": 10, "aB0-_/.:=><+()": 1.2}
 
     # Have to create the run outside of fixtures because the resources dispatch
     # occurs immediately and is not captured by the handler when using the fixture
@@ -313,7 +313,7 @@ def test_log_metrics_offline(
             axes_labels=["x", "y"]
         )
     else:
-        METRICS = {"a": 10, "b": 1.2, "c": 2}
+        METRICS = {"a": 10, "aB0-_/.:=><+()": 1.2, "c": 2}
         
     run.log_metrics(METRICS)
     

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -19,7 +19,7 @@ def test_metrics_creation_online() -> None:
     _values = {
         "x": 1,
         "y": 2.0,
-        "z": True
+        "aB0-_/.:=><+()": True
     }
     _time: int = 1
     _step: int = 1
@@ -40,7 +40,7 @@ def test_metrics_creation_online() -> None:
     )
     assert _metrics.to_dict()
     _metrics.commit()
-    _data = next(_metrics.get(metrics=["x", "y", "z"], runs=[_run.id], xaxis="step"))
+    _data = next(_metrics.get(metrics=["x", "y", "aB0-_/.:=><+()"], runs=[_run.id], xaxis="step"))
     assert sorted(_metrics.names(run_ids=[_run.id])) == sorted(_values.keys())
     assert _data.get(_run.id).get('y')[0].get('value') == 2.0
     assert _data.get(_run.id).get('y')[0].get('step') == 1
@@ -61,7 +61,7 @@ def test_metrics_creation_offline(offline_cache_setup) -> None:
     _values = {
         "x": 1,
         "y": 2.0,
-        "z": True
+        "aB0-_/.:=><+()": True
     }
     _time: int = 1
     _step: int = 1
@@ -93,7 +93,7 @@ def test_metrics_creation_offline(offline_cache_setup) -> None:
 
     # Get online version of metrics
     _online_metrics = Metrics(_id_mapping.get(_metrics.id))
-    _data = next(_online_metrics.get(metrics=["x", "y", "z"], runs=[_id_mapping.get(_run.id)], xaxis="step"))
+    _data = next(_online_metrics.get(metrics=["x", "y", "aB0-_/.:=><+()"], runs=[_id_mapping.get(_run.id)], xaxis="step"))
     assert sorted(_online_metrics.names(run_ids=[_id_mapping.get(_run.id)])) == sorted(_values.keys())
     assert _data.get(_id_mapping.get(_run.id)).get('y')[0].get('value') == 2.0
     assert _data.get(_id_mapping.get(_run.id)).get('y')[0].get('step') == 1


### PR DESCRIPTION
# Fix incorrect metric name validation

**Issue:** #863 

**Python Version(s) Tested:** 3.10

**Operating System(s):** Ubuntu

## 📝 Summary
Regex for metric key validation in the python API did not match that in the server (was missing + and parentheses). Updated to match server

## 🔍 Diagnosis
Bug identified when using ReMKiT connector and parsing variable names like `e-e_odd_C3Il+2_h=2_harmonic_1`
## 🔄 Changes
`METRIC_KEY_REGEX` updated to match server and `log_metrics` tests updated to include a metric name with all allowed characters
## ✔️ Checklist
- [x] Unit and integration tests passing.
- [x] Pre-commit hooks passing.
- [x] Quality checks passing.
