### PR TITLE
Add snapshot functionality to Artifacts

### DIFF
--- a/simvue/api/objects/artifact/file.py
+++ b/simvue/api/objects/artifact/file.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import shutil
 from simvue.config.user import SimvueConfiguration
-import uuid
+from datetime import datetime
 from simvue.models import NAME_REGEX
 from simvue.utilities import get_mimetype_for_file, get_mimetypes, calculate_sha256
 
@@ -87,7 +87,7 @@ class FileArtifact(ArtifactBase):
                 )
                 _local_staging_dir.mkdir(parents=True, exist_ok=True)
                 _local_staging_file = _local_staging_dir.joinpath(
-                    f"{uuid.uuid4()}.file"
+                    f"{file_path.stem}_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S_%f')[:-3]}.file"
                 )
                 shutil.copy(file_path, _local_staging_file)
                 file_path = _local_staging_file

--- a/simvue/api/objects/artifact/file.py
+++ b/simvue/api/objects/artifact/file.py
@@ -124,4 +124,8 @@ class FileArtifact(ArtifactBase):
         with open(_file_orig_path, "rb") as out_f:
             _artifact._upload(file=out_f, timeout=upload_timeout, file_size=_file_size)
 
+        # If snapshot created, delete it after uploading
+        if pathlib.Path(_file_orig_path).parent == _artifact._local_staging_file.parent:
+            pathlib.Path(_file_orig_path).unlink()
+
         return _artifact

--- a/simvue/api/objects/artifact/file.py
+++ b/simvue/api/objects/artifact/file.py
@@ -4,6 +4,9 @@ import typing
 import pydantic
 import os
 import pathlib
+import shutil
+from simvue.config.user import SimvueConfiguration
+import uuid
 from simvue.models import NAME_REGEX
 from simvue.utilities import get_mimetype_for_file, get_mimetypes, calculate_sha256
 
@@ -39,6 +42,7 @@ class FileArtifact(ArtifactBase):
         metadata: dict[str, typing.Any] | None,
         upload_timeout: int | None = None,
         offline: bool = False,
+        snapshot: bool = False,
         **kwargs,
     ) -> Self:
         """Create a new artifact either locally or on the server
@@ -61,6 +65,8 @@ class FileArtifact(ArtifactBase):
             specify the timeout in seconds for upload
         offline : bool, optional
             whether to define this artifact locally, default is False
+        snapshot : bool, optional
+            whether to create a snapshot of this file before uploading it, default is False
 
         """
         _mime_type = mime_type or get_mimetype_for_file(file_path)
@@ -73,6 +79,19 @@ class FileArtifact(ArtifactBase):
             _file_checksum = kwargs.pop("checksum")
         else:
             file_path = pathlib.Path(file_path)
+            if snapshot:
+                _user_config = SimvueConfiguration.fetch()
+
+                _local_staging_dir: pathlib.Path = _user_config.offline.cache.joinpath(
+                    "artifacts"
+                )
+                _local_staging_dir.mkdir(parents=True, exist_ok=True)
+                _local_staging_file = _local_staging_dir.joinpath(
+                    f"{uuid.uuid4()}.file"
+                )
+                shutil.copy(file_path, _local_staging_file)
+                file_path = _local_staging_file
+
             _file_size = file_path.stat().st_size
             _file_orig_path = file_path.expanduser().absolute()
             _file_checksum = calculate_sha256(f"{file_path}", is_file=True)

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -1632,6 +1632,7 @@ class Run:
         category: typing.Literal["input", "output", "code"],
         file_type: str | None = None,
         preserve_path: bool = False,
+        snapshot: bool = False,
         name: typing.Optional[
             typing.Annotated[str, pydantic.Field(pattern=NAME_REGEX)]
         ] = None,
@@ -1652,6 +1653,8 @@ class Run:
             the MIME file type else this is deduced, by default None
         preserve_path : bool, optional
             whether to preserve the path during storage, by default False
+        snapshot : bool, optional
+            whether to take a snapshot of the file before uploading, by default False
         name : str, optional
             name to associate with this file, by default None
         metadata : str | None, optional
@@ -1686,6 +1689,7 @@ class Run:
                 offline=self._user_config.run.mode == "offline",
                 mime_type=file_type,
                 metadata=metadata,
+                snapshot=snapshot,
             )
             _artifact.attach_to_run(self.id, category)
         except (ValueError, RuntimeError) as e:

--- a/tests/unit/test_file_artifact.py
+++ b/tests/unit/test_file_artifact.py
@@ -10,10 +10,15 @@ from simvue.api.objects import FileArtifact, Run, Artifact
 from simvue.api.objects.folder import Folder
 from simvue.sender import sender
 from simvue.client import Client
+import logging
 
 @pytest.mark.api
 @pytest.mark.online
-def test_file_artifact_creation_online() -> None:
+@pytest.mark.parametrize(
+    "snapshot",
+    (True, False)
+)
+def test_file_artifact_creation_online(offline_cache_setup, snapshot) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _folder_name = f"/simvue_unit_testing/{_uuid}"
     _folder = Folder.new(path=_folder_name)
@@ -32,7 +37,8 @@ def test_file_artifact_creation_online() -> None:
             file_path=_path,
             storage=None,
             mime_type=None,
-            metadata=None
+            metadata=None,
+            snapshot=snapshot
         )
         _artifact.attach_to_run(_run.id, "input")
         time.sleep(1)
@@ -45,6 +51,11 @@ def test_file_artifact_creation_online() -> None:
         _content = b"".join(_artifact.download_content()).decode("UTF-8")
         assert _content == f"Hello World! {_uuid}"
         assert _artifact.to_dict()
+        
+        # If snapshotting, check no local copy remains
+        if snapshot:
+            assert len(list(_artifact._local_staging_file.parent.iterdir())) == 0
+
     _run.delete()
     _folder.delete(recursive=True, delete_runs=True, runs_only=False)
     with contextlib.suppress(FileNotFoundError):
@@ -55,7 +66,11 @@ def test_file_artifact_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_file_artifact_creation_offline(offline_cache_setup) -> None:
+@pytest.mark.parametrize(
+    "snapshot",
+    (True, False)
+)
+def test_file_artifact_creation_offline(offline_cache_setup, snapshot) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _folder_name = f"/simvue_unit_testing/{_uuid}"
     _folder = Folder.new(path=_folder_name, offline=True)
@@ -74,7 +89,8 @@ def test_file_artifact_creation_offline(offline_cache_setup) -> None:
         storage=None,
         mime_type=None,
         offline=True,
-        metadata=None
+        metadata=None,
+        snapshot=snapshot
     )
     _artifact.attach_to_run(_run._identifier, category="input")
     
@@ -84,8 +100,14 @@ def test_file_artifact_creation_offline(offline_cache_setup) -> None:
     assert _local_data.get("name") == f"test_file_artifact_{_uuid}"
     assert _local_data.get("runs") == {_run._identifier: "input"}
     
+    # If snapshot, check artifact definition file and a copy of the actual file exist in staging area
+    assert len(list(_artifact._local_staging_file.parent.iterdir())) == 2 if snapshot else 1
+    
     _id_mapping = sender(pathlib.Path(offline_cache_setup.name), 1, 10)
     time.sleep(1)
+    
+    # Check file(s) deleted after upload
+    assert len(list(_artifact._local_staging_file.parent.iterdir())) == 0
     
     _online_artifact = Artifact(_id_mapping[_artifact.id])
     assert _online_artifact.name == _artifact.name
@@ -101,11 +123,11 @@ def test_file_artifact_creation_offline(offline_cache_setup) -> None:
     "snapshot",
     (True, False)
 )
-def test_file_artifact_creation_offline_snapshot(offline_cache_setup, snapshot) -> None:
+def test_file_artifact_creation_offline_updated(offline_cache_setup, caplog, snapshot) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _folder_name = f"/simvue_unit_testing/{_uuid}"
     _folder = Folder.new(path=_folder_name, offline=True)
-    _run = Run.new(name=f"test_file_artifact_creation_offline_snapshot_{_uuid}",folder=_folder_name, offline=True) 
+    _run = Run.new(name=f"test_file_artifact_creation_offline_updated_{_uuid}",folder=_folder_name, offline=True) 
 
     _path = pathlib.Path(offline_cache_setup.name).joinpath("hello_world.txt")
 
@@ -136,8 +158,9 @@ def test_file_artifact_creation_offline_snapshot(offline_cache_setup, snapshot) 
         out_f.write("File changed!")
     
     if not snapshot:
-        with pytest.raises(RuntimeError): # TODO: Make sender be resilient to this?
+        with caplog.at_level(logging.ERROR): 
             _id_mapping = sender(pathlib.Path(offline_cache_setup.name), 1, 10)
+        assert "The SHA256 you specified did not match the calculated checksum." in caplog.text
         return
     else:
         _id_mapping = sender(pathlib.Path(offline_cache_setup.name), 1, 10)

--- a/tests/unit/test_sender.py
+++ b/tests/unit/test_sender.py
@@ -1,0 +1,185 @@
+import contextlib
+import json
+import pytest
+import time
+import datetime
+import uuid
+from simvue.api.objects.run import RunBatchArgs
+from simvue.sender import sender
+from simvue.api.objects import Run, Metrics, Folder
+from simvue.client import Client
+from simvue.models import DATETIME_FORMAT
+import logging
+import pathlib
+import requests
+
+@pytest.mark.parametrize("retry_failed_uploads", (True, False))
+@pytest.mark.parametrize("parallel", (True, False))
+
+@pytest.mark.offline
+def test_sender_exception_handling(offline_cache_setup, caplog, retry_failed_uploads, parallel):
+    # Create something which will produce an error when sent, eg a metric with invalid run ID
+    for i in range(5):
+        _metrics = Metrics.new(
+            run="invalid_run_id",
+            metrics=[
+                {
+                    "timestamp": datetime.datetime.now().strftime(DATETIME_FORMAT),
+                    "time": 1,
+                    "step": 1,
+                    "values": {"x": 1, "y": 2},
+                }
+            ],
+            offline=True
+        )
+        _metrics.commit()
+    
+    with caplog.at_level(logging.ERROR):
+        sender(threading_threshold=1 if parallel else 10)
+            
+    assert "Error while committing 'Metrics'" in caplog.text
+    
+    # Wait, then try sending again
+    time.sleep(1)
+    caplog.clear()
+    
+    with caplog.at_level(logging.ERROR):
+        sender(retry_failed_uploads=retry_failed_uploads, threading_threshold=1 if parallel else 10)
+        
+    if retry_failed_uploads:
+        assert "Error while committing 'Metrics'" in caplog.text
+    else:
+        assert not caplog.text
+        
+    # Check files not deleted
+    _offline_metric_paths = list(pathlib.Path(offline_cache_setup.name).joinpath("metrics").iterdir())
+    assert len(_offline_metric_paths) == 5
+    # Check files have 'upload_failed: True'
+    for _metric_path in _offline_metric_paths:
+        with open(_metric_path, "r") as _file:
+            _metric = json.load(_file)
+            assert _metric.get("upload_failed") == True
+
+@pytest.mark.parametrize("parallel", (True, False))
+def test_sender_server_ids(offline_cache_setup, caplog, parallel):
+    # Create an offline run
+    _uuid: str = f"{uuid.uuid4()}".split("-")[0]
+    _path = f"/simvue_unit_testing/objects/folder/{_uuid}"
+    _folder = Folder.new(path=_path, offline=True)
+    _folder.commit()
+    
+    _offline_run_ids = []
+    
+    for i in range(5):
+        _name = f"test_sender_server_ids-{_uuid}-{i}"
+        _run = Run.new(name=_name, folder=_path, offline=True)
+        _run.commit()
+        
+        _offline_run_ids.append(_run.id)
+        
+        # Create metric associated with offline run ID
+        _metrics = Metrics.new(
+            run=_run.id,
+            metrics=[
+                {
+                    "timestamp": datetime.datetime.now().strftime(DATETIME_FORMAT),
+                    "time": 1,
+                    "step": 1,
+                    "values": {"x": i},
+                }
+            ],
+            offline=True
+        )
+        _metrics.commit()
+    
+    # Send both items
+    with caplog.at_level(logging.ERROR):
+        sender(threading_threshold=1 if parallel else 10)
+    
+    assert not caplog.text
+    
+    # Check server ID mapping correctly created
+    _online_runs = []
+    for i, _offline_run_id in enumerate(_offline_run_ids):
+        _id_file = pathlib.Path(offline_cache_setup.name).joinpath("server_ids", f"{_offline_run_id}.txt")
+        assert _id_file.exists()
+        _online_id = _id_file.read_text()
+    
+        # Check correct ID is contained within file
+        _online_run = Run(identifier=_online_id)
+        _online_runs.append(_online_run)
+        assert _online_run.name == f"test_sender_server_ids-{_uuid}-{i}"
+        
+        # Check metric has been associated with correct online run
+        _run_metric = next(_online_run.metrics)
+        assert _run_metric[0] == 'x'
+        assert _run_metric[1]["count"] == 1
+        assert _run_metric[1]["min"] == i
+    
+        # Create a new offline metric with offline run ID
+        _metrics = Metrics.new(
+            run=_offline_run_id,
+            metrics=[
+                {
+                    "timestamp": datetime.datetime.now().strftime(DATETIME_FORMAT),
+                    "time": 2,
+                    "step": 2,
+                    "values": {"x": 2},
+                }
+            ],
+            offline=True
+        )
+        _metrics.commit()
+    
+    # Run sender again, check online ID is correctly loaded from file and substituted for offline ID
+    with caplog.at_level(logging.ERROR):
+        sender(threading_threshold=1 if parallel else 10)
+    
+    assert not caplog.text
+    
+    # Check metric uploaded correctly
+    for _online_run in _online_runs:
+        _online_run.refresh()
+        _run_metric = next(_online_run.metrics)
+        assert _run_metric[0] == 'x'
+        assert _run_metric[1]["count"] == 2
+        
+    # Check all files for runs and metrics deleted once they were processed
+    assert len(list(pathlib.Path(offline_cache_setup.name).joinpath("runs").iterdir())) == 0
+    assert len(list(pathlib.Path(offline_cache_setup.name).joinpath("metrics").iterdir())) == 0
+
+@pytest.mark.parametrize("parallel", (True, False))
+def test_send_heartbeat(offline_cache_setup, parallel, mocker):
+    # Create an offline run
+    _uuid: str = f"{uuid.uuid4()}".split("-")[0]
+    _path = f"/simvue_unit_testing/objects/folder/{_uuid}"
+    _folder = Folder.new(path=_path, offline=True)
+    _folder.commit()
+    
+    _offline_runs = []
+    
+    for i in range(5):
+        _name = f"test_sender_server_ids-{_uuid}-{i}"
+        _run = Run.new(name=_name, folder=_path, offline=True, heartbeat_timeout=1, status="running")
+        _run.commit()
+        
+        _offline_runs.append(_run)
+    
+    _id_mapping = sender(threading_threshold=1 if parallel else 10)
+    _online_runs = [Run(identifier=_id_mapping.get(_offline_run.id)) for _offline_run in _offline_runs]
+    assert all([_online_run.status == "running" for _online_run in _online_runs])
+    
+    spy_put = mocker.spy(requests, "put")
+    
+    # Create heartbeat and send every 0.5s for 5s
+    for i in range(10):
+        time.sleep(0.5)
+        [_offline_run.send_heartbeat() for _offline_run in _offline_runs]
+        sender(threading_threshold=1 if parallel else 10)
+        
+    # Check requests.put() endpoint called 50 times - once for each of the 5 runs, on all 10 iterations
+    assert spy_put.call_count == 50
+        
+    # Get online runs and check all running
+    [_online_run.refresh() for _online_run in _online_runs]
+    assert all([_online_run.status == "running" for _online_run in _online_runs])


### PR DESCRIPTION
# Fix artifact bugs in offline mode

**Issue:** #870 , #871 , #872 

**Python Version(s) Tested:** 3.10

**Operating System(s):** Ubuntu

## 📝 Summary
If using offline mode, and a file changes between when you called `save_file` and when the user actually uploads the file, the file will fail to upload because the checksum no longer matches. To fix this, have added a new 'snapshot' option to `FileArtifact` and `save_file`, which will copy the file to be uploaded into the simvue cache before calculating the checksum etc. This means that if enabled, the file which is eventually uploaded by the sender will be the version of the file which existed when `save_file` was called.

In the process of this, noticed that errors were not being thrown correctly if the ThreadPoolExecutor was being used to send objects to the server in parallel. Also discussed whether exceptions should be thrown at all, or just logged and continue on. So now any exceptions are logged as errors in the logging framework, but otherwise the sender continues as normal. The cache file is updated with `upload_failed = True` to indicate an attempt has been made but failed. The next time the sender runs, it will try to pop this attribute from the cache file. IF it exists, itll then decide whether to try to upload it again based on the value of a new `retry_failed_uploads` parameter in `sender()`.

## 🔍 Diagnosis

Bug was identified during Remkit connector testing - Remkit updates a config file when it runs to set some keys as default blank values if the user omitted them. This means that in offline mode, the config file was not being uploaded due to the checksum issue, and no error was being reported due to the ThreadPoolExecutor issue. Hopefully this fix addresses both of those!

## 🔄 Changes

* Added `snapshot` option to file artifacts
* Added `retry_failed_uploads` option to sender
* Sender now logs exceptions as errors but does not throw them to make it more resilient, and not block all subsequent sender runs failing if one object fails to upload
* Added tests for sender
* Added tests for snapshot functionality in both online and offline mode

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [ ] Pre-commit hooks passing.
- [ ] Quality checks passing.
